### PR TITLE
Added server mode fuzzing support in winAFL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project(test_netmode)
 
 add_executable(test_netmode test_netmode.cpp)
 
+add_executable(test_servermode test_simple_winsock_client.cpp)
 
 if(NOT "${CMAKE_GENERATOR}" MATCHES "(Win64)")
 
@@ -91,3 +92,4 @@ if (NOT (MSVC_VERSION LESS 1900))
   target_link_libraries(winafl "libvcruntime.lib")
 endif()
 
+add_library(custom_winafl_server SHARED custom_winafl_server.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,4 +92,6 @@ if (NOT (MSVC_VERSION LESS 1900))
   target_link_libraries(winafl "libvcruntime.lib")
 endif()
 
-add_library(custom_winafl_server SHARED custom_winafl_server.cpp)
+add_library(custom_winafl_server SHARED custom_winafl_server.c)
+
+add_library(custom_net_fuzzer SHARED custom_net_fuzzer.c)

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ WinAFL's ```custom_net_fuzzer.dll``` allows winAFL to perform network-based appl
 ```
 For example, if your application receives network packets via UDP protocol at port 7714 you should setup environment variable in the following way: ```set AFL_CUSTOM_DLL_ARGS=-U -p 7714 -a 127.0.0.1 -w 1000 ```
 
-Moreover, you need to enable socket fuzzing via winAFL's option ```-s```. You still need to find target function and make sure that this function receives data from the network, parses it, and returns normally. It is very important to emphasize that in case of network-based fuzzing, the option ```-fuzz_iterations``` is considered as a number of test cases winAFL should send over network before it completely restarts target application.
+You still need to find target function and make sure that this function receives data from the network, parses it, and returns normally. Also, you can use in-app persistence mode described below if your application runs the target function in a loop by its own.
 
 Additionally, this mode is considered as experimental since we have experienced some problems with stability and performance. However, we found this option very usefull and managed to find several vulnerabilities in network-based applications (e.g. in Kollective Kontiki listed above).
 

--- a/README.md
+++ b/README.md
@@ -341,15 +341,6 @@ Examples of use:
 
 ## Custom test cases processing
 
-WinAFL supports third party DLLs that can be used to define custom test-cases processing (e.g. to send test case over network). To enable this option, you need to specify ```-l <path>``` argument.
-The DLL should export the following two functions:
-```
-dll_init()
-dll_run(char *data, long size, int fuzz_iterations) where data - content of test case, size - size of test case, fuzz_iterations - defines a current fuzzing iteration #
-```
-
-## Custom test cases processing
-
 WinAFL supports third party DLLs that can be used to define custom test-cases processing (e.g. to send test cases over network). To enable this option, you need to specify ```-l <path>``` argument.
 The DLL should export the following two functions:
 ```

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ WinAFL's ```custom_net_fuzzer.dll``` allows winAFL to perform network-based appl
 ```
 For example, if your application receives network packets via UDP protocol at port 7714 you should setup environment variable in the following way: ```set AFL_CUSTOM_DLL_ARGS=-U -p 7714 -a 127.0.0.1 -w 1000 ```
 
-You still need to find target function and make sure that this function receives data from the network, parses it, and returns normally. Also, you can use in-app persistence mode described below if your application runs the target function in a loop by its own.
+You still need to find target function and make sure that this function receives data from the network, parses it, and returns normally. Also, you can use In App Persistence mode described above if your application runs the target function in a loop by its own.
 
 Additionally, this mode is considered as experimental since we have experienced some problems with stability and performance. However, we found this option very usefull and managed to find several vulnerabilities in network-based applications (e.g. in Kollective Kontiki listed above).
 

--- a/README.md
+++ b/README.md
@@ -339,9 +339,32 @@ Examples of use:
 <img alt="winafl-cmin.py" src="screenshots/winafl-cmin.py.png"/>
 </p>
 
-## Network fuzzing mode
+## Custom test cases processing
 
-Recently, WinAFL started supporting of network-based applications fuzzing that receive and parse network data. There are several winAFL options to control this process:
+WinAFL supports third party DLLs that can be used to define custom test-cases processing (e.g. to send test case over network). To enable this option, you need to specify ```-l <path>``` argument.
+The DLL should export the following two functions:
+```
+dll_init()
+dll_run(char *data, long size, int fuzz_iterations) where data - content of test case, size - size of test case, fuzz_iterations - defines a current fuzzing iteration #
+```
+
+## Custom test cases processing
+
+WinAFL supports third party DLLs that can be used to define custom test-cases processing (e.g. to send test cases over network). To enable this option, you need to specify ```-l <path>``` argument.
+The DLL should export the following two functions:
+```
+dll_init()
+dll_run(char *data, long size, int fuzz_iterations)
+data - content of test case
+size - size of test case
+fuzz_iterations - defines a current fuzzing iteration number
+```
+
+We have implemented two sample DLLs for network-based applications fuzzing that you can customize for your own purposes.
+
+### Network fuzzing
+
+WinAFL's ```custom_net_fuzzer.dll``` allows winAFL to perform network-based applications fuzzing that receive and parse network data. There are several options supported by this DLL that should be provided via the environment variable ```AFL_CUSTOM_DLL_ARGS```:
 
 ```
   -a IP address - IP address to send data in
@@ -349,12 +372,13 @@ Recently, WinAFL started supporting of network-based applications fuzzing that r
   -p port       - port to send data in
   -w msec       - delay in milliseconds before actually start fuzzing
 ```
+For example, if your application receives network packets via UDP protocol at port 7714 you should setup environment variable in the following way: ```set AFL_CUSTOM_DLL_ARGS=-U -p 7714 -a 127.0.0.1 -w 1000 ```
 
-Basically, you need to add IP address and port to existent winAFL command line arguments to send your test cases over network. You still need to find target function and make sure that this function receives data from network, parses it, and returns normally. It is very important to emphasize that in case of network-based fuzzing, the option ```-fuzz_iterations``` is considered as a number of test cases winAFL should send over network before it completely restarts
-target application.
+Moreover, you need to enable socket fuzzing via winAFL's option ```-s```. You still need to find target function and make sure that this function receives data from the network, parses it, and returns normally. It is very important to emphasize that in case of network-based fuzzing, the option ```-fuzz_iterations``` is considered as a number of test cases winAFL should send over network before it completely restarts target application.
 
-Additionally, this mode is considered as experimental since we have experienced some problems with stability and performance. However, we
-found this option very usefull and managed to find several vulnerabilities in network-based applications (e.g. in Kollective Kontiki listed above).
+Additionally, this mode is considered as experimental since we have experienced some problems with stability and performance. However, we found this option very usefull and managed to find several vulnerabilities in network-based applications (e.g. in Kollective Kontiki listed above).
+
+There is a second DLL ```custom_winafl_server.dll``` that allows winAFL to act as a server and perform fuzzing of client-based applications. All you need is to setup port to listen on for incoming connections from your target application. The environment variable ```AFL_CUSTOM_DLL_ARGS=<port_id>``` should be used for this purpose.
 
 ## Statically instrument a binary via [syzygy](https://github.com/google/syzygy)
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -111,8 +111,7 @@ static u8  skip_deterministic,        /* Skip deterministic stages?       */
            run_over10m,               /* Run time over 10 minutes?        */
            persistent_mode,           /* Running in persistent mode?      */
            drioless = 0;              /* Running without DRIO?            */
-           custom_dll_defined = 0;    /* Custom DLL path defined ?       */
-           enable_socket_fuzzing = 0; /* Enable network fuzzing           */
+           custom_dll_defined = 0;    /* Custom DLL path defined ?        */
 
 static s32 out_fd,                    /* Persistent fd for out_file       */
            dev_urandom_fd = -1,       /* Persistent fd for /dev/urandom   */
@@ -2294,9 +2293,8 @@ static void create_target_process(char** argv) {
   } else {
     pidfile = alloc_printf("childpid_%s.txt", fuzzer_id);
     cmd = alloc_printf(
-        "%s\\drrun.exe -pidfile %s -no_follow_children -c winafl.dll %s %s -fuzzer_id %s -- %s",
-        dynamorio_dir, pidfile, client_params, (enable_socket_fuzzing == 1) ? "-socket_fuzzing": "",
-        fuzzer_id, target_cmd);
+        "%s\\drrun.exe -pidfile %s -no_follow_children -c winafl.dll %s -fuzzer_id %s -- %s",
+        dynamorio_dir, pidfile, client_params, fuzzer_id, target_cmd);
   }
   if(mem_limit || cpu_aff) {
     hJob = CreateJobObject(NULL, NULL);
@@ -7000,8 +6998,7 @@ static void usage(u8* argv0) {
        "  -I msec       - timeout for process initialization and first run\n"
        "  -T text       - text banner to show on the screen\n"
        "  -M \\ -S id    - distributed mode (see parallel_fuzzing.txt)\n"
-       "  -l path       - a path to user-defined DLL for custom test cases processing\n"
-       "  -s            - enable socket fuzzing\n"
+       "  -l path       - a path to user-defined DLL for custom test cases processing\n\n"
 
        "For additional tips, please consult %s\\README.\n\n",
 
@@ -7651,7 +7648,7 @@ int main(int argc, char** argv) {
   dynamorio_dir = NULL;
   client_params = NULL;
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:I:T:dYnCB:S:M:x:QD:b:sl:")) > 0)
+  while ((opt = getopt(argc, argv, "+i:o:f:m:t:I:T:dYnCB:S:M:x:QD:b:l:")) > 0)
 
     switch (opt) {
       case 'i':
@@ -7843,10 +7840,6 @@ int main(int argc, char** argv) {
 
         break;
 
-      case 's':
-        enable_socket_fuzzing = 1;
-
-        break;
       default:
 
         usage(argv[0]);

--- a/config.h
+++ b/config.h
@@ -52,11 +52,6 @@
 
 #define EXEC_TM_ROUND       20
 
-/* Defauly delay in milliseconds to let the target open a socket and start listen for
-   incoming packages.
- */
-#define SOCKET_INIT_DELAY 30000
-
 /* Default memory limit for child process (MB): */
 
 #ifndef __x86_64__ 

--- a/custom_net_fuzzer.c
+++ b/custom_net_fuzzer.c
@@ -1,0 +1,252 @@
+/*
+custom_net_fuzzer - a shared DLL to enable network fuzzing in winAFL
+-------------------------------------------------------------
+
+Written and maintained by Maksim Shudrak <mxmssh@gmail.com>
+
+Copyright 2018 Salesforce Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "custom_winafl_server.h"
+
+static u8  enable_socket_fuzzing = 0; /* Enable network fuzzing           */
+static u8  is_TCP = 1;                /* TCP or UDP                       */
+static u32 target_port = 0x0;         /* Target port to send test cases   */
+static u32 socket_init_delay = SOCKET_INIT_DELAY; /* Socket init delay    */
+static u8 *target_ip_address = NULL;  /* Target IP to send test cases     */
+
+
+static SOCKET ListenSocket = INVALID_SOCKET;
+static SOCKET ClientSocket = INVALID_SOCKET;
+
+static void send_data_tcp(const char *buf, const int buf_len, int first_time) {
+    static struct sockaddr_in si_other;
+    static int slen = sizeof(si_other);
+    static WSADATA wsa;
+    int s;
+
+    if (first_time == 0x0) {
+        /* wait while the target process open the socket */
+        Sleep(socket_init_delay);
+
+        if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+            FATAL("WSAStartup failed. Error Code : %d", WSAGetLastError());
+
+        // setup address structure
+        memset((char *)&si_other, 0, sizeof(si_other));
+        si_other.sin_family = AF_INET;
+        si_other.sin_port = htons(target_port);
+        si_other.sin_addr.S_un.S_addr = inet_addr((char *)target_ip_address);
+    }
+
+    /* In case of TCP we need to open a socket each time we want to establish
+    * connection. In theory we can keep connections always open but it might
+    * cause our target behave differently (probably there are a bunch of
+    * applications where we should apply such scheme to trigger interesting
+    * behavior).
+    */
+    if ((s = socket(AF_INET, SOCK_STREAM, IPPROTO_IP)) == SOCKET_ERROR)
+        FATAL("socket() failed with error code : %d", WSAGetLastError());
+
+    // Connect to server.
+    if (connect(s, (SOCKADDR *)& si_other, slen) == SOCKET_ERROR)
+        FATAL("connect() failed with error code : %d", WSAGetLastError());
+
+    // Send our buffer
+    if (send(s, buf, buf_len, 0) == SOCKET_ERROR)
+        FATAL("send() failed with error code : %d", WSAGetLastError());
+
+    // shutdown the connection since no more data will be sent
+    if (shutdown(s, 0x1/*SD_SEND*/) == SOCKET_ERROR)
+        FATAL("shutdown failed with error: %d\n", WSAGetLastError());
+}
+
+static void send_data_udp(const char *buf, const int buf_len, int first_time) {
+    static struct sockaddr_in si_other;
+    static int s, slen = sizeof(si_other);
+    static WSADATA wsa;
+
+    if (first_time == 0x0) {
+        /* wait while the target process open the socket */
+        Sleep(socket_init_delay);
+
+        if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+            FATAL("WSAStartup failed. Error Code : %d", WSAGetLastError());
+
+        if ((s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == SOCKET_ERROR)
+            FATAL("socket() failed with error code : %d", WSAGetLastError());
+
+        // setup address structure
+        memset((char *)&si_other, 0, sizeof(si_other));
+        si_other.sin_family = AF_INET;
+        si_other.sin_port = htons(target_port);
+        si_other.sin_addr.S_un.S_addr = inet_addr((char *)target_ip_address);
+    }
+
+    // send the data
+    if (sendto(s, buf, buf_len, 0, (struct sockaddr *) &si_other, slen) == SOCKET_ERROR)
+        FATAL("sendto() failed with error code : %d", WSAGetLastError());
+}
+
+#define DEFAULT_BUFLEN 4096
+
+CUSTOM_SERVER_API int APIENTRY dll_run(char *data, long size, int fuzz_iterations) {
+    if (is_TCP)
+        send_data_tcp(data, size, fuzz_iterations);
+    else
+        send_data_udp(data, size, fuzz_iterations);
+    return 1;
+}
+
+static int optind;
+static u8 *optarg;
+
+int getopt(int argc, char **argv, char *optstring) {
+    char *c;
+    optarg = NULL;
+    int i = 0;
+
+    while (1) {
+        if (optind == argc) return -1;
+
+        if (argv[optind][0] != '-') {
+            optind++;
+            continue;
+        }
+        if (!argv[optind][1]) {
+            optind++;
+            continue;
+        }
+
+        c = strchr(optstring, argv[optind][1]);
+        if (!c) {
+            optind++;
+            continue;
+        }
+
+        optind++;
+        if (c[1] == ':') {
+            if (optind == argc) return -1;
+            optarg = argv[optind];
+            optind++;
+        }
+
+        return (int)(c[0]);
+    }
+}
+
+void usage() {
+    printf("Network fuzzing options:\n\n"\
+    "  -a            - IP address to send data in\n"\
+    "  -U            - Use UDP (default TCP)\n"\
+    "  -p            - Port to send data in\n"\
+    "  -w            - Delay in milliseconds before start sending data\n");
+    exit(1);
+}
+static int optind;
+static u8 *optarg;
+
+#define MAX_ARGS 28
+
+char **convert_to_array(char *args, int *argc) {
+    int element_id = 0;
+    int last_element_offset = 0;
+    char *c = NULL;
+
+    int length = strlen(args);
+    char **argv = malloc(MAX_ARGS * sizeof (char *));
+
+    while (args) {
+        c = strchr(args, ' ');
+        if (!c)
+            break;
+
+        int len = c - args;
+        if (len <= 0)
+            break;
+
+        char *element = malloc(len);
+        memcpy(element, args, len);
+        element[len] = '\0';
+
+        argv[element_id] = element;
+
+        element_id++;
+        if (element_id >= MAX_ARGS) {
+            usage();
+            break;
+        }
+
+        args = c + 1;
+    }
+    argv[element_id] = strdup(args);
+
+    *argc = element_id + 1;
+    return argv;
+}
+
+CUSTOM_SERVER_API int APIENTRY dll_init() {
+    s32 opt;
+    static int iSendResult;
+    static int first_time = 0x1;
+    int argc;
+
+    if (!first_time)
+        return 1;
+
+    char *args = getenv("AFL_CUSTOM_DLL_ARGS");
+
+    char **argv = convert_to_array(args, &argc);
+
+    if (args == NULL)
+        usage();
+
+    while ((opt = getopt(argc, argv, "Ua:p:w:")) > 0) {
+        switch (opt) {
+        case 'a':
+            target_ip_address = ck_strdup(optarg);
+
+            break;
+
+        case 'U':
+            is_TCP = 0;
+
+            break;
+
+        case 'p':
+            if (sscanf(optarg, "%u", &target_port) < 1 ||
+                optarg[0] == '-') FATAL("Bad syntax used for -p");
+
+            break;
+
+        case 'w':
+            if (sscanf(optarg, "%u", &socket_init_delay) < 1 ||
+                optarg[0] == '-') FATAL("Bad syntax used for -w");
+
+            break;
+        default:
+            break;
+        }
+    }
+
+    if (target_ip_address == NULL || target_port == 0)
+        usage();
+
+    printf("Ready to begin fuzzing. Target IP= %s, target port = %d\n",
+           target_ip_address, target_port);
+    first_time = 0x0;
+    return 1;
+}

--- a/custom_winafl_server.cpp
+++ b/custom_winafl_server.cpp
@@ -1,0 +1,219 @@
+/*
+custom_winafl_server - a shared DLL to enable server-mode fuzzing in winAFL:
+-------------------------------------------------------------
+
+Written and maintained by Maksim Shudrak <mxmssh@gmail.com>
+
+Copyright 2018 Salesforce Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "custom_winafl_server.h"
+
+static SOCKET ListenSocket = INVALID_SOCKET;
+static SOCKET ClientSocket = INVALID_SOCKET;
+
+#define DEFAULT_BUFLEN 4096
+
+//#define DEBUG_SERVER 1
+
+/* open data and send it back into TCP/UDP socket (winAFL is a server) */
+static int open_file_and_send_response(char *buf, long fsize, SOCKET ClientSocket) {
+	/* send our test case */
+	int iSendResult = send(ClientSocket, buf, fsize, 0);
+	if (iSendResult == SOCKET_ERROR) {
+		printf("send failed with error: %d\n", WSAGetLastError());
+		closesocket(ClientSocket);
+		WSACleanup();
+		ExitProcess(-1);
+		return 0;
+	}
+#ifdef DEBUG_SERVER
+	printf("Bytes sent: %d\n", iSendResult);
+#endif
+
+	return 1;
+}
+
+static int recv_loop(SOCKET ClientSocket) {
+	int iResult;
+	char recvbuf[DEFAULT_BUFLEN];
+	int recvbuflen = DEFAULT_BUFLEN;
+
+	do {
+		iResult = recv(ClientSocket, recvbuf, recvbuflen, 0);
+		if (iResult > 0) {
+#ifdef DEBUG_SERVER
+			printf("Bytes received: %d\n", iResult);
+#endif
+		}
+		else if (iResult == 0) {
+#ifdef DEBUG_SERVER
+			printf("Connection closing...\n");
+#endif
+		}
+		else {
+			printf("recv failed with error: %d\n", WSAGetLastError());
+			closesocket(ClientSocket);
+			WSACleanup();
+			ExitProcess(-1);
+			return 0;
+		}
+	} while (iResult > 0);
+	return 1;
+}
+
+/* winAFL is a TCP server now (TODO: implement UDP server) */
+CUSTOM_SERVER_API int APIENTRY server_init(char *server_bind_port) {
+	static WSADATA wsaData;
+	static int iResult;
+
+	static struct addrinfo *result = NULL;
+	static struct addrinfo hints;
+	static int iSendResult;
+	static int first_time = 0x1;
+
+	if (!first_time)
+		return 1;
+
+	printf("Initializing custom winAFL server\n");
+
+	// Initialize Winsock
+	iResult = WSAStartup(MAKEWORD(2, 2), &wsaData);
+	if (iResult != 0) {
+		printf("WSAStartup failed with error: %d\n", iResult);
+		return 0;
+	}
+
+	ZeroMemory(&hints, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+	hints.ai_flags = AI_PASSIVE;
+
+	// Resolve the server address and port
+	iResult = getaddrinfo(NULL, server_bind_port, &hints, &result);
+	if (iResult != 0) {
+		printf("getaddrinfo failed with error: %d\n", iResult);
+		WSACleanup();
+		return 0;
+	}
+
+	// Create a SOCKET for connecting to server
+	ListenSocket = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
+	if (ListenSocket == INVALID_SOCKET) {
+		printf("socket failed with error: %ld\n", WSAGetLastError());
+		freeaddrinfo(result);
+		WSACleanup();
+		return 0;
+	}
+
+	// Setup the TCP listening socket
+	iResult = bind(ListenSocket, result->ai_addr, (int)result->ai_addrlen);
+	if (iResult == SOCKET_ERROR) {
+		printf("bind failed with error: %d\n", WSAGetLastError());
+		freeaddrinfo(result);
+		closesocket(ListenSocket);
+		WSACleanup();
+		return 0;
+	}
+
+	freeaddrinfo(result);
+
+	iResult = listen(ListenSocket, SOMAXCONN);
+	if (iResult == SOCKET_ERROR) {
+		printf("listen failed with error: %d\n", WSAGetLastError());
+		closesocket(ListenSocket);
+		WSACleanup();
+		ExitProcess(-1);
+		return 0;
+	}
+
+	printf("WinAFL server is listening on port %s", server_bind_port);
+	first_time = 0x0;
+
+	return 1;
+}
+
+#define DEFAULT_BUFLEN 4096
+
+typedef struct _test_case_struct {
+	long size;
+	char *data;
+} test_case_struct;
+
+/* server-mode routings */
+DWORD WINAPI handle_incoming_connection(LPVOID lpParam) {
+	static int iResult;
+	test_case_struct *test_case = (test_case_struct *)lpParam;
+
+#ifdef DEBUG_SERVER
+	printf("Handling incoming connections\n");
+#endif
+
+	// Accept a client socket
+	ClientSocket = accept(ListenSocket, NULL, NULL);
+	if (ClientSocket == INVALID_SOCKET) {
+		printf("accept failed with error: %d\n", WSAGetLastError());
+		closesocket(ListenSocket);
+		WSACleanup();
+		ExitProcess(-1);
+		return 0;
+	}
+
+	recv_loop(ClientSocket);
+
+	/* answer with test case to our client */
+	int res = open_file_and_send_response(test_case->data, test_case->size, ClientSocket);
+
+	if (!res) {
+		printf("Failed to send response");
+		ExitProcess(-1);
+		return 0;
+	}
+
+	// shutdown the connection since we're done
+	iResult = shutdown(ClientSocket, SD_SEND);
+	if (iResult == SOCKET_ERROR) {
+		printf("shutdown failed with error: %d\n", WSAGetLastError());
+		closesocket(ClientSocket);
+		WSACleanup();
+		ExitProcess(-1);
+		return 0;
+	}
+	free(test_case->data);
+	free(test_case);
+	return 1;
+}
+
+HANDLE hr = NULL;
+
+CUSTOM_SERVER_API int APIENTRY server_run(char *data, long size) {
+	DWORD dwThreadId;
+	test_case_struct *test_case = (test_case_struct *)malloc(sizeof(test_case_struct));
+	test_case->data = (char *)malloc(size);
+
+	memcpy(test_case->data, data, size);
+	test_case->size = size;
+
+	/* we have to create a second thread to avoid blocking winAFL in recv */
+	if (hr != NULL)
+		WaitForSingleObject(hr, INFINITE); /* we have to wait our previous thread to finish exec */
+	hr = CreateThread(NULL, 0, handle_incoming_connection, (LPVOID)test_case, 0, &dwThreadId);
+	if (hr == NULL)
+		return 0;
+
+	return 1;
+}

--- a/custom_winafl_server.h
+++ b/custom_winafl_server.h
@@ -22,19 +22,30 @@ limitations under the License.
 #pragma once
 
 #define WIN32_LEAN_AND_MEAN /* prevent winsock.h to be included in windows.h */
+
 #include <stdio.h>
 #include <tchar.h>
 #include <Windows.h>
 #include <wininet.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
+
 #pragma comment(lib,"ws2_32.lib") //Winsock Library
 #pragma comment( lib, "wininet")
 
-#define CUSTOM_SERVER_API extern "C" __declspec(dllexport)
+#include "alloc-inl.h"
 
-CUSTOM_SERVER_API int APIENTRY server_init(char *server_bind_port);
-CUSTOM_SERVER_API int APIENTRY server_run(char *data, long size);
+#define CUSTOM_SERVER_API __declspec(dllexport)
+
+CUSTOM_SERVER_API int APIENTRY dll_init();
+CUSTOM_SERVER_API int APIENTRY dll_run(char *data, long size, int fuzz_iterations);
+
+/* Default delay in milliseconds to let the target open a socket and start listen for
+ * incoming packages.
+*/
+#define SOCKET_INIT_DELAY 30000

--- a/custom_winafl_server.h
+++ b/custom_winafl_server.h
@@ -1,0 +1,40 @@
+/*
+custom_winafl_server - a shared DLL to enable server-mode fuzzing in winAFL:
+-------------------------------------------------------------
+
+Written and maintained by Maksim Shudrak <mxmssh@gmail.com>
+
+Copyright 2018 Salesforce Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN /* prevent winsock.h to be included in windows.h */
+#include <stdio.h>
+#include <tchar.h>
+#include <Windows.h>
+#include <wininet.h>
+#include <stdlib.h>
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#pragma comment(lib,"ws2_32.lib") //Winsock Library
+#pragma comment( lib, "wininet")
+
+#define CUSTOM_SERVER_API extern "C" __declspec(dllexport)
+
+CUSTOM_SERVER_API int APIENTRY server_init(char *server_bind_port);
+CUSTOM_SERVER_API int APIENTRY server_run(char *data, long size);

--- a/test_netmode.cpp
+++ b/test_netmode.cpp
@@ -23,7 +23,7 @@
 /* cmd line to find the crash:
  * afl-fuzz.exe -U -p 7714 -a 127.0.0.1 -w 1000 -i in -o out -D ..\..\dr_release\bin32
  * -t 20000 -- -target_module test_netmode.exe -target_method recv_func -coverage_module test_netmode.exe
- * -fuzz_iterations 50000 -nargs 1 -- ..\Debug\test_netmode.exe
+ * -fuzz_iterations 50000 -nargs 1 -- test_netmode.exe
  */
 
 #define _CRT_SECURE_NO_WARNINGS

--- a/test_netmode.cpp
+++ b/test_netmode.cpp
@@ -21,20 +21,24 @@
 */
 
 /* cmd line to find the crash:
- * afl-fuzz.exe -U -p 7714 -a 127.0.0.1 -w 1000 -i in -o out -D ..\..\dr_release\bin32
- * -t 20000 -- -target_module test_netmode.exe -target_method recv_func -coverage_module test_netmode.exe
- * -fuzz_iterations 50000 -nargs 1 -- test_netmode.exe
+ * set AFL_CUSTOM_DLL_ARGS=-U -p 7714 -a 127.0.0.1 -w 1000
+ * C:\Users\max\Desktop\winafl\winafl_fork\build\Debug>afl-fuzz.exe -l custom_net_fuzzer.dll 
+ * -i in -o out -D ..\..\dr_release\bin32 -t 20000 -- -target_module test_netmode.exe -target_method 
+ * recv_func -coverage_module test_netmode.exe -fuzz_iterations 5000 -nargs 1 -- test_netmode.exe
  */
 
 #define _CRT_SECURE_NO_WARNINGS
 #include <stdio.h>
 #include <windows.h>
 #include <string.h>
+#include <stdlib.h>
 
 #pragma comment(lib,"ws2_32.lib") //Winsock Library
 
 #define DEFAULT_PORT 7714
 #define BUFSIZE 4096
+
+/* TODO: test for TCP */
 
 void error(const char *msg) {
 	printf("[ERROR] %s %d\n", msg, WSAGetLastError());

--- a/test_simple_winsock_client.cpp
+++ b/test_simple_winsock_client.cpp
@@ -1,0 +1,182 @@
+/*
+A client to test winAFL ability act as a TCP/IP fuzzing server:
+-------------------------------------------------------------
+
+Written and maintained by Maksim Shudrak <mxmssh@gmail.com>
+
+Copyright 2018 Salesforce Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+/* cmd line to launch the fuzzer:
+afl-fuzz.exe -l custom_winafl_server.dll -s 1337 -i in -o out -D ..\..\dr_release\bin32 
+-t 20000 -- -target_module simple_winsock_client.exe -target_method main -coverage_module 
+simple_winsock_client.exe -fuzz_iterations 5000 -nargs 1 -- simple_winsock_client.exe
+127.0.0.1
+*/
+
+/* TODO: improve performance of this client under fuzzer */
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <stdio.h>
+#include <tchar.h>
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <stdlib.h>
+
+// Need to link with Ws2_32.lib, Mswsock.lib, and Advapi32.lib
+#pragma comment (lib, "Ws2_32.lib")
+#pragma comment (lib, "Mswsock.lib")
+#pragma comment (lib, "AdvApi32.lib")
+
+#define DEFAULT_BUFLEN 512
+#define DEFAULT_PORT "1337"
+
+void parse_buffer(char *buf) {
+	if (buf[0] == 'P') {
+		if (buf[1] == 'W') {
+			if (buf[2] == 'N') {
+				if (buf[3] == 'I') {
+					if (buf[4] == 'T') {
+						printf("Found it!\n");
+						((VOID(*)())0x0)();
+					}
+				}
+			}
+		}
+	}
+}
+
+void recv_loop(SOCKET ConnectSocket) {
+	char recvbuf[DEFAULT_BUFLEN];
+	int iResult;
+	int recvbuflen = DEFAULT_BUFLEN;
+	// Receive until the peer closes the connection
+	do {
+
+		iResult = recv(ConnectSocket, recvbuf, recvbuflen, 0);
+		if (iResult > 0)
+			printf("Bytes received: %d\n", iResult);
+		else if (iResult == 0)
+			printf("Connection closed\n");
+		else
+			printf("recv failed with error: %d\n", WSAGetLastError());
+
+	} while (iResult > 0);
+	parse_buffer(recvbuf);
+
+}
+
+typedef struct _test_case_struct {
+	long size;
+	char *data;
+} test_case_struct;
+
+int __cdecl main(int argc, char **argv)
+{
+	WSADATA wsaData;
+	SOCKET ConnectSocket = INVALID_SOCKET;
+	struct addrinfo *result = NULL,
+		*ptr = NULL,
+		hints;
+	char *sendbuf = "this is a test";
+	int iResult;
+
+	// Validate the parameters
+	if (argc != 2) {
+		printf("usage: %s server-name\n", argv[0]);
+		return 1;
+	}
+
+	// Initialize Winsock
+	iResult = WSAStartup(MAKEWORD(2, 2), &wsaData);
+	if (iResult != 0) {
+		printf("WSAStartup failed with error: %d\n", iResult);
+		return 1;
+	}
+	ZeroMemory(&hints, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+
+	// Resolve the server address and port
+	iResult = getaddrinfo(argv[1], DEFAULT_PORT, &hints, &result);
+	if (iResult != 0) {
+		printf("getaddrinfo failed with error: %d\n", iResult);
+		WSACleanup();
+		return 1;
+	}
+	// Attempt to connect to an address until one succeeds
+	for (ptr = result; ptr != NULL; ptr = ptr->ai_next) {
+
+		// Create a SOCKET for connecting to server
+		ConnectSocket = socket(ptr->ai_family, ptr->ai_socktype,
+			ptr->ai_protocol);
+		if (ConnectSocket == INVALID_SOCKET) {
+			printf("socket failed with error: %ld\n", WSAGetLastError());
+			WSACleanup();
+			return 1;
+		}
+
+		// Connect to server.
+		iResult = connect(ConnectSocket, ptr->ai_addr, (int)ptr->ai_addrlen);
+		if (iResult == SOCKET_ERROR) {
+			closesocket(ConnectSocket);
+			ConnectSocket = INVALID_SOCKET;
+			continue;
+		}
+		break;
+	}
+
+	freeaddrinfo(result);
+
+	if (ConnectSocket == INVALID_SOCKET) {
+		printf("Unable to connect to server!\n");
+		WSACleanup();
+		return 1;
+	}
+
+	// Send an initial buffer
+	iResult = send(ConnectSocket, sendbuf, (int)strlen(sendbuf), 0);
+	if (iResult == SOCKET_ERROR) {
+		printf("send failed with error: %d\n", WSAGetLastError());
+		closesocket(ConnectSocket);
+		WSACleanup();
+		return 1;
+	}
+	printf("Bytes Sent: %ld\n", iResult);
+
+	// shutdown the connection since no more data will be sent
+	iResult = shutdown(ConnectSocket, SD_SEND);
+	if (iResult == SOCKET_ERROR) {
+		printf("shutdown failed with error: %d\n", WSAGetLastError());
+		closesocket(ConnectSocket);
+		WSACleanup();
+		return 1;
+	}
+
+	recv_loop(ConnectSocket);
+
+	// cleanup
+	closesocket(ConnectSocket);
+	WSACleanup();
+
+	return 0;
+}
+

--- a/test_simple_winsock_client.cpp
+++ b/test_simple_winsock_client.cpp
@@ -21,11 +21,11 @@ limitations under the License.
 */
 
 /* cmd line to launch the fuzzer:
-afl-fuzz.exe -l custom_winafl_server.dll -s 1337 -i in -o out -D ..\..\dr_release\bin32 
--t 20000 -- -target_module simple_winsock_client.exe -target_method main -coverage_module 
-simple_winsock_client.exe -fuzz_iterations 5000 -nargs 1 -- simple_winsock_client.exe
-127.0.0.1
-*/
+ * set AFL_CUSTOM_DLL_ARGS=1337
+ * afl-fuzz.exe -l custom_winafl_server.dll -i in -o out -D ..\..\dr_release\bin32 
+ * -t 20000 -- -target_module test_servermode.exe -target_method main -coverage_module
+ * test_servermode.exe -fuzz_iterations 5000 -nargs 2 -- test_servermode.exe 127.0.0.1
+ */
 
 /* TODO: improve performance of this client under fuzzer */
 
@@ -160,6 +160,7 @@ int __cdecl main(int argc, char **argv)
 		WSACleanup();
 		return 1;
 	}
+
 	printf("Bytes Sent: %ld\n", iResult);
 
 	// shutdown the connection since no more data will be sent

--- a/winafl.c
+++ b/winafl.c
@@ -93,7 +93,6 @@ typedef struct _winafl_option_t {
     int num_fuz_args;
     drwrap_callconv_t callconv;
     bool thread_coverage;
-    bool enable_socket_fuzzing;
 } winafl_option_t;
 static winafl_option_t options;
 
@@ -508,14 +507,12 @@ pre_fuzz_handler(void *wrapcxt, INOUT void **user_data)
     }
 
     //save or restore arguments
-    if (!options.enable_socket_fuzzing) {
-        if (fuzz_target.iteration == 0) {
-            for (i = 0; i < options.num_fuz_args; i++)
-                options.func_args[i] = drwrap_get_arg(wrapcxt, i);
-        } else {
-            for (i = 0; i < options.num_fuz_args; i++)
-                drwrap_set_arg(wrapcxt, i, options.func_args[i]);
-        }
+    if (fuzz_target.iteration == 0) {
+        for (i = 0; i < options.num_fuz_args; i++)
+            options.func_args[i] = drwrap_get_arg(wrapcxt, i);
+    } else {
+        for (i = 0; i < options.num_fuz_args; i++)
+            drwrap_set_arg(wrapcxt, i, options.func_args[i]);
     }
 
     memset(winafl_data.afl_area, 0, MAP_SIZE);
@@ -539,10 +536,6 @@ post_fuzz_handler(void *wrapcxt, void *user_data)
         debug_data.post_handler_called++;
         dr_fprintf(winafl_data.log, "In post_fuzz_handler\n");
     }
-
-    /* We don't need to reload context in case of network-based fuzzing. */
-    if (options.enable_socket_fuzzing)
-        return;
 
     fuzz_target.iteration++;
     if(fuzz_target.iteration == options.fuzz_iterations) {
@@ -819,7 +812,6 @@ options_init(client_id_t id, int argc, const char *argv[])
     options.fuzz_method[0] = 0;
     options.fuzz_offset = 0;
     options.fuzz_iterations = 1000;
-    options.enable_socket_fuzzing = false;
     options.func_args = NULL;
     options.num_fuz_args = 0;
     options.callconv = DRWRAP_CALLCONV_DEFAULT;
@@ -904,9 +896,6 @@ options_init(client_id_t id, int argc, const char *argv[])
                 options.callconv = DRWRAP_CALLCONV_MICROSOFT_X64;
             else
                 NOTIFY(0, "Unknown calling convention, using default value instead.\n");
-        }
-        else if (strcmp(token, "-socket_fuzzing") == 0) {
-            options.enable_socket_fuzzing = true;
         }
 		else if (strcmp(token, "-persistence_mode") == 0) {
 			USAGE_CHECK((i + 1) < argc, "missing mode arg: '-fuzz_mode' arg");


### PR DESCRIPTION
1) WinAFL now supports server mode fuzzing to test clients. User need to specify a third-party DLL where he/she should define communication logic with a client.
2) Added default server DLL for winAFL.
3) Added test for server-mode fuzzing support.