### PR TITLE
fixed afl-tmin and afl-showmap bug I've introduced with in app persis…

### DIFF
--- a/afl-showmap.c
+++ b/afl-showmap.c
@@ -703,6 +703,18 @@ static void run_target(char** argv) {
   child_timed_out = 0;
   memset(trace_bits, 0, MAP_SIZE);
 
+  //TEMPORARY FIX FOR REGULAR USAGE OF AFL-TMIN
+  ReadFile(pipe_handle, &result, 1, &num_read, NULL);
+  if (result == 'K')
+  {
+	  //a workaround for first cycle
+	  ReadFile(pipe_handle, &result, 1, &num_read, NULL);
+  }
+  if (result != 'P')
+  {
+	  FATAL("Unexpected result from pipe! expected 'P', instead received '%c'\n", result);
+  }
+  //END OF TEMPORARY FIX FOR REGULAR USAGE OF AFL-TMIN
   WriteFile( 
     pipe_handle,  // handle to pipe 
     command,      // buffer to write from 

--- a/afl-tmin.c
+++ b/afl-tmin.c
@@ -699,6 +699,18 @@ static u8 run_target(char** argv, u8* mem, u32 len, u8 first_run) {
   memset(trace_bits, 0, MAP_SIZE);
   MemoryBarrier();
 
+  //TEMPORARY FIX FOR REGULAR USAGE OF AFL-TMIN
+  ReadFile(pipe_handle, &result, 1, &num_read, NULL);
+  if (result == 'K')
+  {
+	  //a workaround for first cycle
+	  ReadFile(pipe_handle, &result, 1, &num_read, NULL);
+  }
+  if (result != 'P')
+  {
+	  FATAL("Unexpected result from pipe! expected 'P', instead received '%c'\n", result);
+  }
+  //END OF TEMPORARY FIX FOR REGULAR USAGE OF AFL-TMIN
   WriteFile(
     pipe_handle,  // handle to pipe
     command,      // buffer to write from


### PR DESCRIPTION
Hey Ivan, as mentioned by @masthoon in:
https://github.com/googleprojectzero/winafl/pull/120
The changes I've made to winafl.c reflected into afl-tmin and afl-showmap.

I've issued a fix for both that should process my additional pipe message from the target.

NOTE: we should refactor all the code related to 'run_target' outside of the 3 different projects for proper code reuse
it will also benefit us in easier implementation of new features regarding information reception from winafl, I don't have time for this right now, but I'll definitely do it in the near future to address a new crash directory structure I have that will help with crash triage of same bugs that occur from different paths.