### PR TITLE
Enable proxy mode for fuzzing software running in other domains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,12 @@ if (${INTELPT})
 
 endif()
 
+project(afl-proxy)
+
+add_definitions(-DAFL_PROXY_MODE)
+
+add_library(afl-proxy SHARED afl-staticinstr.c)
+
 if (NOT "${DynamoRIO_DIR}" STREQUAL "")
 
   project(WinAFL)

--- a/afl-staticinstr.c
+++ b/afl-staticinstr.c
@@ -556,6 +556,12 @@ Return Value:
     }
 
     //
+    // Tell afl-fuzz that we are ready for the next iteration.
+    //
+
+    WriteFile(g_winafl_pipe, "P", 1, &Dummy, NULL);
+
+    //
     // Wait until we have the go from afl-fuzz to go ahead (below call is blocking).
     //
 

--- a/afl-staticinstr.h
+++ b/afl-staticinstr.h
@@ -31,8 +31,10 @@
 #include <stdint.h>
 #include <tchar.h>
 
+#ifndef AFL_PROXY_MODE
 #if defined(_M_X64) || defined(__amd64__)
 #error Static instrumentation is only available for 32 bit binaries
+#endif
 #endif
 
 //
@@ -45,6 +47,7 @@
 extern "C" {
 #endif
 
+__declspec(dllexport)
 BOOL __afl_persistent_loop();
 
 #ifdef __cplusplus


### PR DESCRIPTION
This pull request adds a proxy library to support the "proxy mode" that allows a target program to act as a proxy for fuzzing software in other domains (e.g., the operating system kernel).  It also fixed a bug in afl-staticinstr.c which fails to send a "P" command that is expected from afl-fuzz.exe.