### PR TITLE
Fix a protocol broken issue

### DIFF
--- a/afl-staticinstr.c
+++ b/afl-staticinstr.c
@@ -556,6 +556,12 @@ Return Value:
     }
 
     //
+    // Tell afl-fuzz that we are ready for the next iteration.
+    //
+
+    WriteFile(g_winafl_pipe, "P", 1, &Dummy, NULL);
+
+    //
     // Wait until we have the go from afl-fuzz to go ahead (below call is blocking).
     //
 


### PR DESCRIPTION
This pull request fixed a communication bug where afl-staticinstr fails to send the "P" command expected by afl-fuzz.exe.