### PR TITLE
Support x64 build with VS2019

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(test_netmode test_netmode.cpp)
 
 add_executable(test_servermode test_simple_winsock_client.cpp)
 
-if(NOT "${CMAKE_GENERATOR}" MATCHES "(Win64)")
+if(NOT ("${CMAKE_GENERATOR}" MATCHES "(Win64)" OR "${CMAKE_GENERATOR_PLATFORM}" MATCHES "(64)"))
 
   project(test_static)
 


### PR DESCRIPTION
Starting from VS2019 target platform (Win32/x64) is passed to cmake as a separate argument -A (architecture) and ends up in CMAKE_GENERATOR_PLATFORM variable rather than part of CMAKE_GENERATOR.