### PR TITLE
crash codes

### DIFF
--- a/winafl.c
+++ b/winafl.c
@@ -201,10 +201,10 @@ void WriteCommandToPipe(char cmd)
 	WriteFile(pipe, &cmd, 1, &num_written, NULL);
 }
 
-void WriteDWORDCommandToPipe(char* cmd)
+void WriteDWORDCommandToPipe(DWORD data)
 {
 	DWORD num_written;
-	WriteFile(pipe, cmd, 4, &num_written, NULL);
+	WriteFile(pipe, &data, sizeof(DWORD), &num_written, NULL);
 }
 
 
@@ -217,10 +217,6 @@ dump_winafl_data()
 static bool
 onexception(void *drcontext, dr_exception_t *excpt) {
     DWORD exception_code = excpt->record->ExceptionCode;
-	char pipeCommand[4];
-
-	memset(pipeCommand, 0, 4);
-	memcpy(pipeCommand , &exception_code, 4);
 
     if(options.debug_mode)
         dr_fprintf(winafl_data.log, "Exception caught: %x\n", exception_code);
@@ -237,7 +233,7 @@ onexception(void *drcontext, dr_exception_t *excpt) {
                 dr_fprintf(winafl_data.log, "crashed\n");
             } else {
 				WriteCommandToPipe('C');
-				WriteDWORDCommandToPipe(pipeCommand);
+				WriteDWORDCommandToPipe(exception_code);				
             }
             dr_exit_process(1);
     }

--- a/winafl.c
+++ b/winafl.c
@@ -201,6 +201,13 @@ void WriteCommandToPipe(char cmd)
 	WriteFile(pipe, &cmd, 1, &num_written, NULL);
 }
 
+void WriteDWORDCommandToPipe(char* cmd)
+{
+	DWORD num_written;
+	WriteFile(pipe, cmd, 4, &num_written, NULL);
+}
+
+
 static void
 dump_winafl_data()
 {
@@ -210,6 +217,10 @@ dump_winafl_data()
 static bool
 onexception(void *drcontext, dr_exception_t *excpt) {
     DWORD exception_code = excpt->record->ExceptionCode;
+	char pipeCommand[4];
+
+	memset(pipeCommand, 0, 4);
+	memcpy(pipeCommand , &exception_code, 4);
 
     if(options.debug_mode)
         dr_fprintf(winafl_data.log, "Exception caught: %x\n", exception_code);
@@ -226,6 +237,7 @@ onexception(void *drcontext, dr_exception_t *excpt) {
                 dr_fprintf(winafl_data.log, "crashed\n");
             } else {
 				WriteCommandToPipe('C');
+				WriteDWORDCommandToPipe(pipeCommand);
             }
             dr_exit_process(1);
     }


### PR DESCRIPTION
thanks ivan. closing my previous pull request and opening this new request as per the changes suggested by you. please review and let me know if its ok now.
1. added a global DWORD ret_exception_code.
2. added new functions ReadDWORDFromPipe in afl-fuzz.c and WriteDWORDCommandToPipe in winafl.c
3. added switch for exception names in save_if_interesting function. 