### PR TITLE
Add check for specifying CPU affinity

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -8037,10 +8037,10 @@ int main(int argc, char** argv) {
         if (cpu_aff) {
           FATAL("Multiple -c options not supported");
         } else {
-          u32 cpunum = 0;
+          int cpunum = 0;
 
-          if (sscanf(optarg, "%u", &cpunum) < 1 ||
-              optarg[0] == '-') FATAL("Bad syntax used for -c");
+          if (sscanf(optarg, "%d", &cpunum) < 1 ||
+              cpunum < 0) FATAL("Bad syntax used for -c");
 
           if (cpunum >= 64)
             FATAL("Uh-oh, winafl doesn't support more than 64 cores at the moment\n");

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -465,7 +465,7 @@ static void bind_to_free_cpu(void) {
   if (cpu_core_count > 64) {
     SAYF("\n" cLRD "[-] " cRST
     "Uh-oh, looks like you have %u CPU cores on your system\n"
-    "    winafl doesn't support more than 64 cores at the momement\n"
+    "    winafl doesn't support more than 64 cores at the moment\n"
     "    you can set AFL_NO_AFFINITY and try again.\n",
     cpu_core_count);
     FATAL("Too many cpus for automatic binding");
@@ -8036,11 +8036,14 @@ int main(int argc, char** argv) {
 
         if (cpu_aff) {
           FATAL("Multiple -c options not supported");
-        }
-        else {
-          int cpunum = 0;
+        } else {
+          u32 cpunum = 0;
 
-          if (sscanf(optarg, "%d", &cpunum) < 1) FATAL("Bad syntax used for -c");
+          if (sscanf(optarg, "%u", &cpunum) < 1 ||
+              optarg[0] == '-') FATAL("Bad syntax used for -c");
+
+          if (cpunum >= 64)
+            FATAL("Uh-oh, winafl doesn't support more than 64 cores at the moment\n");
 
           cpu_aff = 1ULL << cpunum;
         }


### PR DESCRIPTION
* The specified CPU core should be less than 64 (winafl doesn't support more than 64 cores at the moment).
* The specified CPU core should be not allocated.