### PR TITLE
FIX: cycles_wo_finds should be reset when appending new test case

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -814,6 +814,8 @@ static void mark_as_redundant(struct queue_entry* q, u8 state) {
 
 static void add_to_queue(u8* fname, u32 len, u8 passed_det) {
 
+  cycles_wo_finds = 0;
+
   struct queue_entry* q = ck_alloc(sizeof(struct queue_entry));
 
   q->fname        = fname;


### PR DESCRIPTION
`cycles_wo_finds` (cycles without any new paths) should be reset when appending new test case.