### PR TITLE
Documentation Update - VS2019 & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cmake --build . --config Release
 ```
 mkdir build64
 cd build64
-cmake -G"Visual Studio 15 2017 Win64" .. -DDynamoRIO_DIR=..\path\to\DynamoRIO\cmake -DINTELPT=1
+cmake -G"Visual Studio 16 2019" -A x64 .. -DDynamoRIO_DIR=..\path\to\DynamoRIO\cmake -DINTELPT=1
 cmake --build . --config Release
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ source directory).
 ```
 mkdir build32
 cd build32
-cmake -G"Visual Studio 15 2017" .. -DDynamoRIO_DIR=..\path\to\DynamoRIO\cmake -DINTELPT=1
+cmake -G"Visual Studio 16 2019" .. -DDynamoRIO_DIR=..\path\to\DynamoRIO\cmake -DINTELPT=1
 cmake --build . --config Release
 ```
 


### PR DESCRIPTION
The build documentation in README is out of date for VS 2019.

The current documentation causes this issue:
```
CMake Error: Could not create named generator Visual Studio 16 2019 Win64

Generators
* Visual Studio 16 2019        = Generates Visual Studio 2019 project files.
                                 Use -A option to specify architecture.
  Visual Studio 15 2017 [arch] = Generates Visual Studio 2017 project files.
                                 Optional [arch] can be "Win64" or "ARM".
...
```

I attempted to fix this originally by switching from `cmake -G"Visual Studio 15 2017 Win64"` to `cmake -G"Visual Studio 1 2019" -A Win64`, but that caused another error.

I discovered the fix of using `-A x64` instead from [here](http://cmake.3232098.n2.nabble.com/Can-t-Generate-Project-Files-for-VS2019-td7599413.html).

My commit for 32 bit may not be correct. Opening WinAFL.sln seems to show only x64.

Specifying `-A x86`, however, does not work either. It gives me the error:
`error MSB8013: This project doesn't contain the Configuration and Platform combination of Debug|Win32. [C:\Users\gdynamics\source\repos\winafl\build32\CMakeFiles\3.17.20032601-MSVC_2\VCTargetsPath.vcxproj]`

I am not sure if this because some build file is out of date, I am doing it wrong, or if x64 is being generated because cmake is defaulting to the arch of the system.

**In conclusion**
 I can confirm the x64 documentation update is correct, but the x86 documentation update may not be, and someone may want to confirm or deny that part.
![image](https://user-images.githubusercontent.com/17126217/98899011-6db02a00-2474-11eb-8fd0-40b5c41718b9.png)

I believe I am good in terms of the CLA, as well.
![image](https://user-images.githubusercontent.com/17126217/98899045-7dc80980-2474-11eb-962a-7fe2661a6d84.png)