### PR TITLE
User-provided mutation function with energy

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ setsockopt(s, SOL_SOCKET, SO_LINGER, (char*)&opt, sizeof(int));
 
 ## Custom mutators
 
-WinAFL supports loading a custom mutator from a third-party DLL.  You need to implement `dll_mutate_testcase` in your DLL and provide the DLL path to WinAFL via `-l <path>` argument.  WinAFL invokes the custom mutator before all the built-in mutations, and the custom mutator can skip all the built-in mutations by returning a non-zero value.  The custom mutator should invoke `common_fuzz_stuff` to run and make WinAFL aware of each new test case.  Below is an example mutator that increments every byte by one: 
+WinAFL supports loading a custom mutator from a third-party DLL.  You need to implement `dll_mutate_testcase` or `dll_mutate_testcase_with_energy` in your DLL and provide the DLL path to WinAFL via `-l <path>` argument.  WinAFL invokes the custom mutator before all the built-in mutations, and the custom mutator can skip all the built-in mutations by returning a non-zero value.  The `dll_mutate_testcase_with_energy` function is additionally provided an energy value that is equivalent to the number of iterations expected to run in the havoc stage without deterministic mutations. The custom mutator should invoke `common_fuzz_stuff` to run and make WinAFL aware of each new test case.  Below is an example mutator that increments every byte by one: 
 
 ```c
 u8 dll_mutate_testcase(char **argv, u8 *buf, u32 len, u8 (*common_fuzz_stuff)(char**, u8*, u32))

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2559,12 +2559,16 @@ typedef u8 (APIENTRY* dll_run_target)(char**, u32, char*, u32);
 typedef void (APIENTRY *dll_write_to_testcase)(char*, s32, const void*, u32);
 typedef u8 (APIENTRY* dll_mutate_testcase)(char**, u8*, u32, u8 (*)(char **, u8*, u32));
 
+// Parameters: argv, in_buf, buffer_length, mutation_iterations, common_fuzz_stuff
+typedef u8 (APIENTRY* dll_mutate_testcase_with_energy)(char**, u8*, u32, u32, u8 (*)(char **, u8*, u32));
+
 // custom server functions
 dll_run dll_run_ptr = NULL;
 dll_init dll_init_ptr = NULL;
 dll_run_target dll_run_target_ptr = NULL;
 dll_write_to_testcase dll_write_to_testcase_ptr = NULL;
 dll_mutate_testcase dll_mutate_testcase_ptr = NULL;
+dll_mutate_testcase_with_energy dll_mutate_testcase_with_energy_ptr = NULL;
 
 char *get_test_case(long *fsize)
 {
@@ -5335,7 +5339,14 @@ static u8 fuzz_one(char** argv) {
    * CUSTOM MUTATOR *
    *****************/
 
-  if (dll_mutate_testcase_ptr)
+  stage_max = HAVOC_CYCLES_INIT * perf_score / havoc_div / 100;
+  if (stage_max < HAVOC_MIN) stage_max = HAVOC_MIN;
+
+  // Prefer a mutator that accepts the energy.
+  if (dll_mutate_testcase_with_energy_ptr)
+    if (dll_mutate_testcase_with_energy_ptr(argv, in_buf, len, stage_max, common_fuzz_stuff))
+      goto abandon_entry;
+  else if (dll_mutate_testcase_ptr)
     if (dll_mutate_testcase_ptr(argv, in_buf, len, common_fuzz_stuff))
       goto abandon_entry;
 
@@ -7805,6 +7816,10 @@ void load_custom_library(const char *libname)
   // Get pointer to user-defined mutate_testcase function using GetProcAddress:
   dll_mutate_testcase_ptr = (dll_mutate_testcase)GetProcAddress(hLib, "dll_mutate_testcase");
   SAYF("dll_mutate_testcase %s defined.\n", dll_mutate_testcase_ptr ? "is" : "isn't");
+
+  // Get pointer to user-defined dll_mutate_testcase_with_energy_ptr function using GetProcAddress:
+  dll_mutate_testcase_with_energy_ptr = (dll_mutate_testcase_with_energy)GetProcAddress(hLib, "dll_mutate_testcase_with_energy");
+  SAYF("dll_mutate_testcase_with_energy %s defined.\n", dll_mutate_testcase_with_energy_ptr ? "is" : "isn't");
 
   SAYF("Sucessfully loaded and initalized\n");
 }

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -5339,12 +5339,9 @@ static u8 fuzz_one(char** argv) {
    * CUSTOM MUTATOR *
    *****************/
 
-  stage_max = HAVOC_CYCLES_INIT * perf_score / havoc_div / 100;
-  if (stage_max < HAVOC_MIN) stage_max = HAVOC_MIN;
-
-  // Prefer a mutator that accepts the energy.
+  // Prefer a custom mutator that accepts the performance score as an energy value.
   if (dll_mutate_testcase_with_energy_ptr)
-    if (dll_mutate_testcase_with_energy_ptr(argv, in_buf, len, stage_max, common_fuzz_stuff))
+    if (dll_mutate_testcase_with_energy_ptr(argv, in_buf, len, perf_score, common_fuzz_stuff))
       goto abandon_entry;
   else if (dll_mutate_testcase_ptr)
     if (dll_mutate_testcase_ptr(argv, in_buf, len, common_fuzz_stuff))


### PR DESCRIPTION
The user-provided mutation function is a great feature in WinAFL.  However, if it is used as a replacement for both the deterministic and havoc mutations, it should use an energy value that determines how many mutants to create from the input.  This allows the genetic algorithm to prioritize some queue items.  The havoc stage uses a similar value.  The energy was set to the value used by havoc if the deterministic mutations are skipped.

The custom mutator is expected to implement the looping. For example, if the mutator must somehow parse the input data before mutating it, it can be done once before starting the loop. This should be faster than looping `dll_mutate_testcase_ptr` in afl-fuzz.c.