### PR TITLE
Add support for using WinAFL as a pre-configured tool for DynamoRIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ The following afl-fuzz options are supported:
   -t msec       - timeout for each run
   -s            - deliver sample via shared memory
   -D dir        - directory containing DynamoRIO binaries (drrun, drconfig)
+  -w path       - path to winafl.dll
+  -e            - expert mode to run WinAFL as a DynamoRIO tool
   -P            - use Intel PT tracing mode
   -Y            - enable the static instrumentation mode
   -f file       - location read by the fuzzed program

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ The following afl-fuzz options are supported:
   -t msec       - timeout for each run
   -s            - deliver sample via shared memory
   -D dir        - directory containing DynamoRIO binaries (drrun, drconfig)
-  -w path       - path to winafl.dll
   -P            - use Intel PT tracing mode
   -Y            - enable the static instrumentation mode
   -f file       - location read by the fuzzed program

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2444,9 +2444,10 @@ static void create_target_process(char** argv) {
     inherit_handles = FALSE;
   }
 
-  client_invocation = alloc_printf("-c %s", winafl_dll_path);
   if (expert_mode) {
     client_invocation = alloc_printf("-t winafl");
+  } else {
+    client_invocation = alloc_printf("-c %s", winafl_dll_path);
   }
 
   if(drioless) {
@@ -2566,6 +2567,7 @@ static void create_target_process(char** argv) {
     child_pid = pi.dwProcessId;
   }
 
+  ck_free(client_invocation);
   ck_free(target_cmd);
   ck_free(cmd);
   ck_free(pipe_name);

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -8347,6 +8347,8 @@ int main(int argc, char** argv) {
 
   if (!winafl_dll_path) {
     winafl_dll_path = "winafl.dll";
+  } else if (expert_mode) {
+    FATAL("-w and -e are mutually exclusive");
   }
 
   setup_signal_handlers();

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7393,6 +7393,7 @@ static void usage(u8* argv0) {
        "  -T text       - text banner to show on the screen\n"
        "  -M \\ -S id   - distributed mode (see parallel_fuzzing.txt)\n"
        "  -C            - crash exploration mode (the peruvian rabbit thing)\n"
+       "  -e            - expert mode to run WinAFL as a DynamoRIO tool\n"
        "  -l path       - a path to user-defined DLL for custom test cases processing\n\n"
        "Attach:\n"
        "  -A module     - attach to the process that loaded the provided module\n\n"

--- a/readme_dr.md
+++ b/readme_dr.md
@@ -196,11 +196,10 @@ First, create a file in the `tools` subdirectory of the root of DynamoRIO called
 `CLIENT_REL` or `CLIENT_ABS` options enable `drrun` to locate the WinAFL client
 library. This file can also modify the default DynamoRIO runtime options (see
 DynamoRIO Runtime Options) via `DR_OP=` lines. As an example for a 32-bit build,
-this file should contain at least the following lines:
+this file should contain at least the following line:
 
 ```
 CLIENT_REL=tools/lib32/release/winafl.dll
-DR_OP=-no_follow_children
 ```
 
 The `-msgbox_mask` option controls whether DynamoRIO uses pop-up message boxes
@@ -211,4 +210,39 @@ memory limit specified with the `-m` option:
 ```
 DR_OP=-msgbox_mask
 DR_OP=0x0
+```
+
+Tool options can also be specified via `TOOL_OP=` lines. As an example, append
+the following lines to this file for a complete configuration to start fuzzing
+using the supplied `test_gdiplus.exe`:
+
+```
+TOOL_OP=-covtype
+TOOL_OP=edge
+TOOL_OP=-coverage_module
+TOOL_OP=gdiplus.dll
+TOOL_OP=-fuzz_iterations
+TOOL_OP=1000
+TOOL_OP=-target_module
+TOOL_OP=test_gdiplus.exe
+TOOL_OP=-target_method
+TOOL_OP=main
+TOOL_OP=-nargs
+TOOL_OP=2
+```
+
+Now you can omit the client parameters from the command line as all the required
+options are set in the tool configuration file.
+
+Make sure that the target is running correctly using WinAFL as a DynamoRIO tool:
+
+```
+drrun.exe -t winafl -debug -- test_gdiplus.exe input.bmp
+```
+
+If everything appears to be working correctly, launch `afl-fuzz.exe` in expert
+mode using the `-e` switch:
+
+```
+afl-fuzz.exe -e -i in -o out -D <dynamorio bin path> -t 100+ -- -- test_gdiplus.exe @@
 ```

--- a/readme_dr.md
+++ b/readme_dr.md
@@ -105,35 +105,9 @@ iteration. Note the list of loaded modules for setting the -coverage_module
 flag. Note that you must use the same values for module names as seen in the
 log file (not case sensitive).
 
-4. The DynamoRIO client implemented in the `winafl.dll` can be packaged up with
-DynamoRIO to create an end-user tool, hence using `drrun` for WinAFL is made
-simpler by the `-t` option. First, create a file in the `tools` subdirectory of
-the root of DynamoRIO called `winafl.drrun32` or `winafl.drrun64`, depending on
-the target architecture. The `CLIENT_REL` or `CLIENT_ABS` options enable `drrun`
-to locate the WinAFL client library. This file can also modify the default
-DynamoRIO runtime options (see DynamoRIO Runtime Options) via `DR_OP=` lines.
-As an example for a 32-bit build, this file should contain at least the
-following lines:
-
-```
-CLIENT_REL=tools/lib32/release/winafl.dll
-DR_OP=-no_follow_children
-```
-
-The `-msgbox_mask` option controls whether DynamoRIO uses pop-up message boxes
-when presenting information. As an example, append the following lines to this
-file to disable out of memory notices in case the target process reaches
-the memory limit specified with the `-m` option:
-
-```
-DR_OP=-msgbox_mask
-DR_OP=0x0
-```
-
-5. Now you should be ready to fuzz the target. First, make sure that both
-afl-fuzz.exe and winafl.dll are in the current directory and that winafl.dll
-is also available at the path specified by the `CLIENT_REL` or `CLIENT_ABS`
-option. As stated earlier, the command line for afl-fuzz on Windows is:
+4. Now you should be ready to fuzz the target. First, make sure that both
+afl-fuzz.exe and winafl.dll are in the current directory. As stated earlier,
+the command line for afl-fuzz on Windows is:
 
 ```
 afl-fuzz [afl options] -- [instrumentation options] -- target_cmd_line
@@ -210,3 +184,31 @@ afl-fuzz.exe -i in -o out -D <dynamorio bin path> -t 100+ -- -coverage_module te
 ```
 
 
+## Expert mode
+
+The DynamoRIO client implemented in the `winafl.dll` can be packaged up with
+DynamoRIO to create an end-user tool, hence using `drrun` for WinAFL is made
+simpler by the `-t` option. This is possible by running `afl-fuzz.exe` in
+expert mode enabled by the `-e` switch.
+
+First, create a file in the `tools` subdirectory of the root of DynamoRIO called
+`winafl.drrun32` or `winafl.drrun64`, depending on the target architecture. The
+`CLIENT_REL` or `CLIENT_ABS` options enable `drrun` to locate the WinAFL client
+library. This file can also modify the default DynamoRIO runtime options (see
+DynamoRIO Runtime Options) via `DR_OP=` lines. As an example for a 32-bit build,
+this file should contain at least the following lines:
+
+```
+CLIENT_REL=tools/lib32/release/winafl.dll
+DR_OP=-no_follow_children
+```
+
+The `-msgbox_mask` option controls whether DynamoRIO uses pop-up message boxes
+when presenting information. As an example, append the following lines to this
+file to disable out of memory notices in case the target process reaches the
+memory limit specified with the `-m` option:
+
+```
+DR_OP=-msgbox_mask
+DR_OP=0x0
+```

--- a/readme_dr.md
+++ b/readme_dr.md
@@ -105,9 +105,35 @@ iteration. Note the list of loaded modules for setting the -coverage_module
 flag. Note that you must use the same values for module names as seen in the
 log file (not case sensitive).
 
-4. Now you should be ready to fuzz the target. First, make sure that both
-afl-fuzz.exe and winafl.dll are in the current directory. As stated earlier,
-the command line for afl-fuzz on Windows is:
+4. The DynamoRIO client implemented in the `winafl.dll` can be packaged up with
+DynamoRIO to create an end-user tool, hence using `drrun` for WinAFL is made
+simpler by the `-t` option. First, create a file in the `tools` subdirectory of
+the root of DynamoRIO called `winafl.drrun32` or `winafl.drrun64`, depending on
+the target architecture. The `CLIENT_REL` or `CLIENT_ABS` options enable `drrun`
+to locate the WinAFL client library. This file can also modify the default
+DynamoRIO runtime options (see DynamoRIO Runtime Options) via `DR_OP=` lines.
+As an example for a 32-bit build, this file should contain at least the
+following lines:
+
+```
+CLIENT_REL=tools/lib32/release/winafl.dll
+DR_OP=-no_follow_children
+```
+
+The `-msgbox_mask` option controls whether DynamoRIO uses pop-up message boxes
+when presenting information. As an example, append the following lines to this
+file to disable out of memory notices in case the target process reaches
+the memory limit specified with the `-m` option:
+
+```
+DR_OP=-msgbox_mask
+DR_OP=0x0
+```
+
+5. Now you should be ready to fuzz the target. First, make sure that both
+afl-fuzz.exe and winafl.dll are in the current directory and that winafl.dll
+is also available at the path specified by the `CLIENT_REL` or `CLIENT_ABS`
+option. As stated earlier, the command line for afl-fuzz on Windows is:
 
 ```
 afl-fuzz [afl options] -- [instrumentation options] -- target_cmd_line


### PR DESCRIPTION
This PR switches from using WinAFL as a simple client (`drrun.exe -c winafl.dll -- notepad`) to using it as a pre-configured tool (`drrun.exe -t winafl -- notepad`) to run alongside DynamoRIO.

> A tool is a client with a configuration file that sets the client options and path, providing a convenient launching command via the `-t` parameter.

A [tool](https://dynamorio.org/page_deploy.html#tool_frontend) can be configured by creating a file in the `tools` subdirectory of the root of the DynamoRIO installation called  `winafl.drrun32` or  `winafl.drrun64`, depending on the target architecture. The `CLIENT_ABS` or `CLIENT_REL` specifiers enable `drrun` to locate the `winafl.dll` client library. 

As an example for a 32-bit build, the configuration file should contain at least the following lines:

```
CLIENT_REL=tools/lib32/release/winafl.dll
DR_OP=-no_follow_children
```

The default [DynamoRIO runtime options](https://dynamorio.org/page_deploy.html#sec_options) can be also modified in the tool configuration file via `DR_OP=` lines, hence this PR also addresses #230:

```
DR_OP=-msgbox_mask
DR_OP=0x0
```
Note that this PR removes the `-w` option used to specify the path of `winafl.dll`, because this can be done in the tool configuration file, as mentioned above.