### PR TITLE
Backporting AFL improvements to WinAFL

### DIFF
--- a/afl-analyze.c
+++ b/afl-analyze.c
@@ -310,7 +310,7 @@ static void write_to_file(u8* path, u8* mem, u32 len) {
   s32 ret;
 
   _unlink(path); /* Ignore errors */
-  ret = _open(path, O_RDWR | O_CREAT | O_EXCL | O_BINARY, 0600);
+  ret = _open(path, O_RDWR | O_CREAT | O_EXCL | O_BINARY, DEFAULT_PERMISSION);
 
   if (ret < 0) PFATAL("Unable to create '%s'", path);
 

--- a/afl-analyze.c
+++ b/afl-analyze.c
@@ -1139,6 +1139,10 @@ static void usage(u8* argv0) {
 
        "  -e            - look for edge coverage only, ignore hit counts\n\n"
 
+       "Other stuff:\n\n"
+
+       "  -V            - show version number and exit\n\n"
+
        "For additional tips, please consult %s/README.\n\n",
 
        argv0, EXEC_TIMEOUT, MEM_LIMIT, doc_path);
@@ -1259,7 +1263,7 @@ int main(int argc, char** argv) {
   SAYF("Based on WinAFL " cBRI VERSION cRST " by <ifratric@google.com>\n");
   SAYF("Based on AFL " cBRI VERSION cRST " by <lcamtuf@google.com>\n");
   
-  while ((opt = getopt(argc,argv,"+i:f:m:t:D:eQY")) > 0)
+  while ((opt = getopt(argc,argv,"+i:f:m:t:D:eQYV")) > 0)
 
     switch (opt) {
 
@@ -1345,6 +1349,11 @@ int main(int argc, char** argv) {
         drioless = 1;
 
         break;
+
+      case 'V': /* Show version number */
+
+        /* Version number has been printed already, just quit. */
+        exit(0);
 
       default:
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -853,7 +853,8 @@ static void add_to_queue(u8* fname, u32 len, u8 passed_det) {
   queued_paths++;
   pending_not_fuzzed++;
 
-  if (!(queued_paths % 100)) {
+  /* Set next_100 pointer for every 100th element (index 0, 100, etc) to allow faster iteration. */
+  if ((queued_paths - 1) % 100 == 0 && queued_paths > 1) {
 
     q_prev100->next_100 = q;
     q_prev100 = q;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7371,8 +7371,10 @@ static void usage(u8* argv0) {
        "  -M \\ -S id   - distributed mode (see parallel_fuzzing.txt)\n"
        "  -C            - crash exploration mode (the peruvian rabbit thing)\n"
        "  -e            - expert mode to run WinAFL as a DynamoRIO tool\n"
-       "  -l path       - a path to user-defined DLL for custom test cases processing\n\n"
-       "Attach:\n"
+       "  -l path       - a path to user-defined DLL for custom test cases processing\n"
+       "  -V            - show version number and exit\n\n"
+
+       "Attach:\n\n"
        "  -A module     - attach to the process that loaded the provided module\n\n"
 
        "For additional tips, please consult %s\\README.\n\n",
@@ -8033,7 +8035,7 @@ int main(int argc, char** argv) {
   client_params = NULL;
   winafl_dll_path = NULL;
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:I:T:sdYnCB:S:M:x:QD:b:l:pPc:w:A:e")) > 0)
+  while ((opt = getopt(argc, argv, "+i:o:f:m:t:I:T:sdYnCB:S:M:x:QD:b:l:pPc:w:A:eV")) > 0)
 
     switch (opt) {
       case 's':
@@ -8284,6 +8286,11 @@ int main(int argc, char** argv) {
         if (expert_mode) FATAL("Multiple -e options not supported");
         expert_mode = 1;
         break;
+
+     case 'V': /* Show version number */
+
+        /* Version number has been printed already, just quit. */
+        exit(0);
 
       default:
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -767,7 +767,7 @@ static void mark_as_det_done(struct queue_entry* q) {
 
   fn = alloc_printf("%s\\queue\\.state\\deterministic_done\\%s", out_dir, fn + 1);
 
-  fd = _open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+  fd = _open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
   if (fd < 0) PFATAL("Unable to create '%s'", fn);
   _close(fd);
 
@@ -813,7 +813,7 @@ static void mark_as_redundant(struct queue_entry* q, u8 state) {
 
   if (state) {
 
-    fd = _open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+    fd = _open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
     if (fd < 0) PFATAL("Unable to create '%s'", fn);
     _close(fd);
 
@@ -898,7 +898,7 @@ static void write_bitmap(void) {
   bitmap_changed = 0;
 
   fname = alloc_printf("%s\\fuzz_bitmap", out_dir);
-  fd = _open(fname, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC, 0600);
+  fd = _open(fname, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC, DEFAULT_PERMISSION);
 
   if (fd < 0) PFATAL("Unable to open '%s'", fname);
 
@@ -2115,7 +2115,7 @@ static void save_auto(void) {
     u8* fn = alloc_printf("%s\\queue\\.state\\auto_extras\\auto_%06u", out_dir, i);
     s32 fd;
 
-    fd = _open(fn, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC, 0600);
+    fd = _open(fn, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC, DEFAULT_PERMISSION);
 
     if (fd < 0) PFATAL("Unable to create '%s'", fn);
 
@@ -2141,7 +2141,7 @@ static void load_auto(void) {
     u8* fn = alloc_printf("%s\\.state\\auto_extras\\auto_%06u", in_dir, i);
     s32 fd, len;
 
-    fd = _open(fn, O_RDONLY | O_BINARY, 0600);
+    fd = _open(fn, O_RDONLY | O_BINARY, DEFAULT_PERMISSION);
 
     if (fd < 0) {
 
@@ -2953,14 +2953,14 @@ static void write_to_testcase(void* mem, u32 len) {
 
     unlink(out_file); /* Ignore errors. */
 
-    fd = open(out_file, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+    fd = open(out_file, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
 
     if (fd < 0) {
       destroy_target_process(0);
       
 	  unlink(out_file); /* Ignore errors. */
 
-	  fd = open(out_file, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+	  fd = open(out_file, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
 		
       if (fd < 0) PFATAL("Unable to create '%s'", out_file);
 
@@ -3353,7 +3353,7 @@ static void link_or_copy(u8* old_path, u8* new_path) {
   sfd = open(old_path, O_RDONLY | O_BINARY);
   if (sfd < 0) PFATAL("Unable to open '%s'", old_path);
 
-  dfd = open(new_path, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+  dfd = open(new_path, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
   if (dfd < 0) PFATAL("Unable to create '%s'", new_path);
 
   tmp = ck_alloc(64 * 1024);
@@ -3515,7 +3515,7 @@ static void write_crash_readme(void) {
   s32 fd;
   FILE* f;
 
-  fd = open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+  fd = open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
   ck_free(fn);
 
   /* Do not die on errors here - that would be impolite. */
@@ -3603,7 +3603,7 @@ static u8 save_if_interesting(char** argv, void* mem, u32 len, u8 fault) {
     if (res == FAULT_ERROR)
       FATAL("Unable to execute target application");
 
-    fd = open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+    fd = open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
     if (fd < 0) PFATAL("Unable to create '%s'", fn);
     ck_write(fd, mem, len, fn);
     close(fd);
@@ -3761,7 +3761,7 @@ static u8 save_if_interesting(char** argv, void* mem, u32 len, u8 fault) {
   /* If we're here, we apparently want to save the crash or hang
      test case, too. */
 
-  fd = open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+  fd = open(fn, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
   if (fd < 0) PFATAL("Unable to create '%s'", fn);
   ck_write(fd, mem, len, fn);
   close(fd);
@@ -3854,7 +3854,7 @@ static void write_stats_file(double bitmap_cvg, double stability, double eps) {
   s32 fd;
   FILE* f;
 
-  fd = open(fn, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC, 0600);
+  fd = open(fn, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC, DEFAULT_PERMISSION);
 
   if (fd < 0) PFATAL("Unable to create '%s'", fn);
 
@@ -5021,7 +5021,7 @@ write_trimmed:
 
     unlink(q->fname); /* ignore errors */
 
-    fd = open(q->fname, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+    fd = open(q->fname, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
 
     if (fd < 0) PFATAL("Unable to create '%s'", q->fname);
 
@@ -7142,7 +7142,7 @@ static void sync_fuzzers(char** argv) {
 
 	qd_synced_path = alloc_printf("%s\\.synced\\%s", out_dir, sd.cFileName);
 
-    id_fd = open(qd_synced_path, O_RDWR | O_BINARY | O_CREAT, 0600);
+    id_fd = open(qd_synced_path, O_RDWR | O_BINARY | O_CREAT, DEFAULT_PERMISSION);
 
     if (id_fd < 0) PFATAL("Unable to create '%s'", qd_synced_path);
 
@@ -7487,7 +7487,7 @@ static void setup_dirs_fds(void) {
   /* Gnuplot output file. */
 
   tmp = alloc_printf("%s\\plot_data", out_dir);
-  fd = open(tmp, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, 0600);
+  fd = open(tmp, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
   if (fd < 0) PFATAL("Unable to create '%s'", tmp);
   ck_free(tmp);
 
@@ -7523,7 +7523,7 @@ static void setup_stdio_file(void) {
 
   unlink(fn); /* Ignore errors */
 
-  out_fd = open(fn, O_RDWR | O_BINARY | O_CREAT | O_EXCL, 0600);
+  out_fd = open(fn, O_RDWR | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
 
   if (out_fd < 0) PFATAL("Unable to create '%s'", fn);
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -6408,7 +6408,7 @@ skip_interest:
   stage_name  = "user extras (insert)";
   stage_short = "ext_UI";
   stage_cur   = 0;
-  stage_max   = extras_cnt * len;
+  stage_max   = extras_cnt * (len + 1);
 
   orig_hit_cnt = new_hit_cnt;
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -5483,6 +5483,12 @@ static u8 fuzz_one(char** argv) {
 
     if (queue_cur->cal_failed < CAL_CHANCES) {
 
+      /* Reset exec_cksum to tell calibrate_case to re-execute the testcase
+         avoiding the usage of an invalid trace_bits.
+         For more info: https://github.com/AFLplusplus/AFLplusplus/pull/425 */
+
+      queue_cur->exec_cksum = 0;
+
       res = calibrate_case(argv, queue_cur, in_buf, queue_cycle - 1, 0);
 
       if (res == FAULT_ERROR)

--- a/afl-showmap.c
+++ b/afl-showmap.c
@@ -851,7 +851,8 @@ static void usage(u8* argv0) {
        "Other settings:\n\n"
 
        "  -q            - sink program's output and don't show messages\n"
-       "  -e            - show edge coverage only, ignore hit counts\n\n"
+       "  -e            - show edge coverage only, ignore hit counts\n"
+       "  -V            - show version number and exit\n\n"
 
        "This tool displays raw tuple data captured by AFL instrumentation.\n"
        "For additional help, consult %s\\README.\n\n" cRST,
@@ -1077,6 +1078,11 @@ int main(int argc, char** argv) {
         if (dynamorio_dir) FATAL("Dynamic-instrumentation (DRIO) is uncompatible with static-instrumentation");
         drioless = 1;
         break;
+
+      case 'V':
+
+        show_banner();
+        exit(0);
 
       default:
 

--- a/afl-showmap.c
+++ b/afl-showmap.c
@@ -284,7 +284,7 @@ static u32 write_results(void) {
 
   if (!strncmp(out_file, "/dev/", 5)) {
 
-    fd = _open(out_file, O_WRONLY, 0600);
+    fd = _open(out_file, O_WRONLY, DEFAULT_PERMISSION);
     if (fd < 0) PFATAL("Unable to open '%s'", out_file);
 
   } else if (!strcmp(out_file, "-")) {
@@ -295,7 +295,7 @@ static u32 write_results(void) {
   } else {
 
     _unlink(out_file); /* Ignore errors */
-    fd = _open(out_file, O_WRONLY | O_CREAT | O_EXCL, 0600);
+    fd = _open(out_file, O_WRONLY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
     if (fd < 0) PFATAL("Unable to create '%s'", out_file);
 
   }

--- a/afl-tmin.c
+++ b/afl-tmin.c
@@ -336,7 +336,7 @@ static void write_to_file(u8* path, u8* mem, u32 len) {
 
   _unlink(path); /* Ignore errors */
 
-  ret = _open(path, O_RDWR | O_CREAT | O_EXCL | O_BINARY, 0600);
+  ret = _open(path, O_RDWR | O_CREAT | O_EXCL | O_BINARY, DEFAULT_PERMISSION);
 
   if (ret < 0) PFATAL("Unable to create '%s'", path);
 

--- a/afl-tmin.c
+++ b/afl-tmin.c
@@ -1152,6 +1152,10 @@ static void usage(u8* argv0) {
        "  -e            - solve for edge coverage only, ignore hit counts\n"
        "  -x            - treat non-zero exit codes as crashes\n\n"
 
+       "Other stuff:\n\n"
+
+       "  -V            - show version number and exit\n\n"
+
        "For additional tips, please consult %s/README.\n\n",
 
        argv0, EXEC_TIMEOUT, MEM_LIMIT, doc_path);
@@ -1282,7 +1286,7 @@ int main(int argc, char** argv) {
   SAYF("Based on WinAFL " cBRI VERSION cRST " by <ifratric@google.com>\n");
   SAYF("Based on AFL " cBRI VERSION cRST " by <lcamtuf@google.com>\n");
 
-  while ((opt = getopt(argc,argv,"+i:o:f:m:t:B:D:xeQY")) > 0)
+  while ((opt = getopt(argc,argv,"+i:o:f:m:t:B:D:xeQYV")) > 0)
 
     switch (opt) {
 
@@ -1402,6 +1406,11 @@ int main(int argc, char** argv) {
         drioless = 1;
 
         break;
+
+     case 'V': /* Show version number */
+
+        /* Version number has been printed already, just quit. */
+        exit(0);
 
       default:
 

--- a/config.h
+++ b/config.h
@@ -35,6 +35,9 @@
  *                                                    *
  ******************************************************/
 
+/* Default file permission umode when creating files (default: 0600) */
+#define DEFAULT_PERMISSION  0600
+
 /* Comment out to disable terminal colors: */
 
 // #define USE_COLOR


### PR DESCRIPTION
This PR backports the following bug fixes or improvements from the AFL and AFL++ projects:

- Fix next_100 pointers by google/AFL@fab1ca5ed7e3552833a18fc2116d33a9241699bc
- Fix counting stage execs for user inserts by google/AFL@2abd3f4041269d1a64562e31147078234542dc9b
- Fix the issue with testcase calibration failure not being respected by google/AFL@ee6ffe6347fc282d7bb6f0d869acb37c74ea8ef8
- Add option -V: Show version number and exit by google/AFL@fcf734aab735b0e6652aa9f549ba41c0fde05d4d
- Add file permission setting to config.h by AFLplusplus/AFLplusplus@dfe6f7f8c949744eeab7a401affde93729a5b39d