### PR TITLE
Backporting AFL++ improvements for in-place resume

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -107,6 +107,7 @@ static u8  skip_deterministic,        /* Skip deterministic stages?       */
            no_forkserver,             /* Disable forkserver?              */
            crash_mode,                /* Crash mode! Yeah!                */
            in_place_resume,           /* Attempt in-place resume?         */
+           autoresume,                /* Resume if out_dir exists?        */
            auto_changed,              /* Auto-generated tokens changed?   */
            no_cpu_meter_red,          /* Feng shui on the status screen   */
            no_arith,                  /* Skip most arithmetic ops         */
@@ -4145,6 +4146,11 @@ static void maybe_delete_out_dir(void) {
 
     fclose(f);
 
+    /* Autoresume treats a normal run as in_place_resume if a valid out dir
+       already exists. */
+
+    if (!in_place_resume && autoresume) in_place_resume = 1;
+
     /* Let's see how much work is at stake. */
 
     if (!in_place_resume && last_update - start_time > OUTPUT_GRACE * 60) {
@@ -4156,8 +4162,8 @@ static void maybe_delete_out_dir(void) {
 
            "    If you wish to start a new session, remove or rename the directory manually,\n"
            "    or specify a different output location for this job. To resume the old\n"
-           "    session, put '-' as the input directory in the command line ('-i -') and\n"
-           "    try again.\n", OUTPUT_GRACE);
+           "    session, put '-' as the input directory in the command line ('-i -') or\n"
+           "    set the AFL_AUTORESUME=1 env variable and try again.\n", OUTPUT_GRACE);
 
        FATAL("At-risk data found in '%s'", out_dir);
 
@@ -8396,6 +8402,7 @@ int main(int argc, char** argv) {
   if (getenv("AFL_NO_ARITH"))      no_arith = 1;
   if (getenv("AFL_SHUFFLE_QUEUE")) shuffle_queue    = 1;
   if (getenv("AFL_NO_SINKHOLE"))   sinkhole_stds    = 0;
+  if (getenv("AFL_AUTORESUME"))    autoresume       = 1;
 
   if (dumb_mode == 2 && no_forkserver)
     FATAL("AFL_DUMB_FORKSRV and AFL_NO_FORKSRV are mutually exclusive");

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -4290,9 +4290,11 @@ static void maybe_delete_out_dir(void) {
     ck_free(fn);
   }
 
-  fn = alloc_printf("%s\\plot_data", out_dir);
-  if (unlink(fn) && errno != ENOENT) goto dir_cleanup_failed;
-  ck_free(fn);
+  if (!in_place_resume) {
+    fn = alloc_printf("%s\\plot_data", out_dir);
+    if (unlink(fn) && errno != ENOENT) goto dir_cleanup_failed;
+    ck_free(fn);
+  }
 
   fn = alloc_printf("%s\\drcache", out_dir);
   if(delete_subdirectories(fn)) goto dir_cleanup_failed;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -3956,10 +3956,11 @@ static void maybe_update_plot_file(double bitmap_cvg, double eps) {
   static u32 prev_qp, prev_pf, prev_pnf, prev_ce, prev_md;
   static u64 prev_qc, prev_uc, prev_uh;
 
-  if (prev_qp == queued_paths && prev_pf == pending_favored && 
+  if ((prev_qp == queued_paths && prev_pf == pending_favored &&
       prev_pnf == pending_not_fuzzed && prev_ce == current_entry &&
       prev_qc == queue_cycle && prev_uc == unique_crashes &&
-      prev_uh == unique_hangs && prev_md == max_depth) return;
+      prev_uh == unique_hangs && prev_md == max_depth) ||
+      (get_cur_time() - start_time <= 60)) return;
 
   prev_qp  = queued_paths;
   prev_pf  = pending_favored;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -3934,8 +3934,8 @@ static void write_stats_file(double bitmap_cvg, double stability, double eps) {
              "afl_banner        : %s\n"
              "afl_version       : " VERSION "\n"
              "command_line      : %s\n",
-             start_time / 1000, cur_time / 1000, (cur_time - start_time) / 1000, GetCurrentProcessId(),
-             queue_cycle ? (queue_cycle - 1) : 0, total_execs, eps,
+             (start_time - prev_run_time) / 1000, cur_time / 1000, (prev_run_time + cur_time - start_time) / 1000, GetCurrentProcessId(),
+             queue_cycle ? (queue_cycle - 1) : 0, total_execs, total_execs / ((double)(prev_run_time + cur_time - start_time) / 1000),
              queued_paths, queued_favored, queued_discovered, queued_imported,
              max_depth, current_entry, pending_favored, pending_not_fuzzed,
              queued_variable, stability, bitmap_cvg, unique_crashes,
@@ -4388,7 +4388,7 @@ static void show_stats(void) {
 
   if (!last_execs) {
   
-    avg_exec = ((double)total_execs) * 1000 / (cur_ms - start_time);
+    avg_exec = ((double)total_execs) * 1000 / (prev_run_time + cur_ms - start_time);
 
   } else {
 
@@ -4532,7 +4532,7 @@ static void show_stats(void) {
 
   SAYF(bV bSTOP "        run time : " cRST "%-34s " bSTG bV bSTOP
        "  cycles done : %s%-4s  " bSTG bV "\n",
-       DTD(cur_ms, start_time), tmp, DI(queue_cycle - 1));
+       DTD(prev_run_time + cur_ms, start_time), tmp, DI(queue_cycle - 1));
 
   /* We want to warn people about not seeing new paths after a full cycle,
      except when resuming fuzzing or running in non-instrumented mode. */

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -3972,13 +3972,13 @@ static void maybe_update_plot_file(double bitmap_cvg, double eps) {
 
   /* Fields in the file:
 
-     unix_time, cycles_done, cur_path, paths_total, paths_not_fuzzed,
+     relative_time, cycles_done, cur_path, paths_total, paths_not_fuzzed,
      favored_not_fuzzed, unique_crashes, unique_hangs, max_depth,
      execs_per_sec */
 
   fprintf(plot_file, 
           "%llu, %llu, %u, %u, %u, %u, %0.02f%%, %llu, %llu, %u, %0.02f\n",
-          get_cur_time() / 1000, queue_cycle - 1, current_entry, queued_paths,
+          ((prev_run_time + get_cur_time() - start_time) / 1000), queue_cycle - 1, current_entry, queued_paths,
           pending_not_fuzzed, pending_favored, bitmap_cvg, unique_crashes,
           unique_hangs, max_depth, eps); /* ignore errors */
 
@@ -7536,7 +7536,7 @@ static void setup_dirs_fds(void) {
     plot_file = fdopen(fd, "w");
     if (!plot_file) PFATAL("fdopen() failed");
 
-    fprintf(plot_file, "# unix_time, cycles_done, cur_path, paths_total, "
+    fprintf(plot_file, "# relative_time, cycles_done, cur_path, paths_total, "
                      "pending_total, pending_favs, map_size, unique_crashes, "
                      "unique_hangs, max_depth, execs_per_sec\n");
                      /* ignore errors */

--- a/afl_docs/env_variables.txt
+++ b/afl_docs/env_variables.txt
@@ -86,6 +86,10 @@ will have a more striking effect. For this tool, 0 is not a valid choice.
 The main fuzzer binary accepts several options that disable a couple of sanity
 checks or alter some of the more exotic semantics of the tool:
 
+  - Setting AFL_AUTORESUME will resume a fuzz run (same as providing `-i -`)
+    for an existing out folder, even if a different `-i` was provided.
+    Without this setting, afl-fuzz will refuse execution for a long-fuzzed out dir.
+
   - Setting AFL_SKIP_CPUFREQ skips the check for CPU scaling policy. This is
     useful if you can't change the defaults (e.g., no root access to the
     system) and are OK with some performance loss.

--- a/winafl-plot.py
+++ b/winafl-plot.py
@@ -24,9 +24,9 @@ set terminal png truecolor enhanced size 1000,300 butt
 
 set output '{outdir}/high_freq.png'
 
-set xdata time
-set timefmt '%s'
-set format x "%b %d\\n%H:%M"
+#set xdata time
+#set timefmt '%s'
+#set format x "%b %d\\n%H:%M"
 set tics font 'small'
 unset mxtics
 unset mytics
@@ -39,6 +39,8 @@ set key outside
 
 set autoscale xfixmin
 set autoscale xfixmax
+
+set xlabel "relative time in seconds" font "small"
 
 plot '{fuzzer_dir}/plot_data' using 1:4 with filledcurve x1 title 'total paths' linecolor rgb '#000000' fillstyle transparent solid 0.2 noborder, \\
      '' using 1:3 with filledcurve x1 title 'current path' linecolor rgb '#f0f0f0' fillstyle transparent solid 0.5 noborder, \\


### PR DESCRIPTION
This PR backports some improvements for in-place resume from the AFL++ project. It adds `run_time` and `prev_run_time` and applies them in time calculations for the UI, `fuzzer_stats` and `plot_data`.

Furthermore, it adds an `AFL_AUTORESUME` environment variable to enable automatically resuming a fuzzing session, if an output directory already exists and also loads some variables from the existing `fuzzer_stats` file.

The related backported commits are the following:
- Preserve `plot_data` for in-place resume by AFLplusplus/AFLplusplus@62508c3b446a893f0afead9a6d0546d53d588a13
- Update `plot_data` with relative timestamps when resuming by AFLplusplus/AFLplusplus@7e67a735e6a30550288fc8c35541f91ea4cf3de3
- Load `prev_run_time` from `fuzzer_stats` when resuming by AFLplusplus/AFLplusplus@1a8c242d280066b7bfb36897c91215d4f4b5eb01
- Update `afl-plot` to use relative time by AFLplusplus/AFLplusplus@ceb138cefe46e4412f54f31a812c125cebbb5b65
- Apply `prev_run_time` to UI and `fuzzer_stats` file by AFLplusplus/AFLplusplus@96cdc97c98ee2e2af7df59252f4f0df1689afb7b
- Wait for 60 secs before writing the initial `plot_data` by AFLplusplus/AFLplusplus@15dd4ad177b4822ad25eaec26897bb55e5cd5785
- Add `AFL_AUTORESUME` env variable by AFLplusplus/AFLplusplus@6865cd8d691385f805a63b62f9836abf98061e4f
- Load existing `fuzzer_stats` when resuming by AFLplusplus/AFLplusplus@6f163bb0c50a103dc4565ec5f0b8b9b94b5c16f6