### PR TITLE
Fix error when writing trimmed test case

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -5018,10 +5018,13 @@ write_trimmed:
   if (needs_write) {
 
     s32 fd;
+    int oflag = O_WRONLY | O_BINARY | O_CREAT;
 
-    unlink(q->fname); /* ignore errors */
-
-    fd = open(q->fname, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
+    if (!unlink(q->fname)) {
+        fd = open(q->fname, oflag | O_EXCL, DEFAULT_PERMISSION);
+    } else {
+        fd = open(q->fname, oflag | O_TRUNC, DEFAULT_PERMISSION);
+    }
 
     if (fd < 0) PFATAL("Unable to create '%s'", q->fname);
 


### PR DESCRIPTION
This PR attempts to fix an error due to `unlink` failing when updating a test case after trimming by falling back to truncating the file. AFL++ follows a similar approach using an additional `-N` flag added by AFLplusplus/AFLplusplus@f8bc9b54dabc759e9ad1eb82e5ee36af3bb4e1a6.