### PR TITLE
Remove redundant file API calls (unlink before open, seek before close)

### DIFF
--- a/afl-analyze.c
+++ b/afl-analyze.c
@@ -309,14 +309,12 @@ static void write_to_file(u8* path, u8* mem, u32 len) {
 
   s32 ret;
 
-  _unlink(path); /* Ignore errors */
-  ret = _open(path, O_RDWR | O_CREAT | O_EXCL | O_BINARY, DEFAULT_PERMISSION);
+  ret = _open(path, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, DEFAULT_PERMISSION);
 
   if (ret < 0) PFATAL("Unable to create '%s'", path);
 
   ck_write(ret, mem, len, path);
 
-  _lseek(ret, 0, SEEK_SET);
   _close(ret);
 
 }

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2956,16 +2956,12 @@ static void write_to_testcase(void* mem, u32 len) {
 
   if (out_file) {
 
-    unlink(out_file); /* Ignore errors. */
-
-    fd = open(out_file, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
+    fd = open(out_file, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC, DEFAULT_PERMISSION);
 
     if (fd < 0) {
       destroy_target_process(0);
       
-	  unlink(out_file); /* Ignore errors. */
-
-	  fd = open(out_file, O_WRONLY | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
+	  fd = open(out_file, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC, DEFAULT_PERMISSION);
 		
       if (fd < 0) PFATAL("Unable to create '%s'", out_file);
 
@@ -5134,13 +5130,8 @@ write_trimmed:
   if (needs_write) {
 
     s32 fd;
-    int oflag = O_WRONLY | O_BINARY | O_CREAT;
 
-    if (!unlink(q->fname)) {
-        fd = open(q->fname, oflag | O_EXCL, DEFAULT_PERMISSION);
-    } else {
-        fd = open(q->fname, oflag | O_TRUNC, DEFAULT_PERMISSION);
-    }
+    fd = open(q->fname, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC, DEFAULT_PERMISSION);
 
     if (fd < 0) PFATAL("Unable to create '%s'", q->fname);
 
@@ -7664,9 +7655,7 @@ static void setup_stdio_file(void) {
   
   u8* fn = alloc_printf("%s\\.cur_input", out_dir);
 
-  unlink(fn); /* Ignore errors */
-
-  out_fd = open(fn, O_RDWR | O_BINARY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
+  out_fd = open(fn, O_RDWR | O_BINARY | O_CREAT | O_TRUNC, DEFAULT_PERMISSION);
 
   if (out_fd < 0) PFATAL("Unable to create '%s'", fn);
 

--- a/afl-showmap.c
+++ b/afl-showmap.c
@@ -294,8 +294,7 @@ static u32 write_results(void) {
 
   } else {
 
-    _unlink(out_file); /* Ignore errors */
-    fd = _open(out_file, O_WRONLY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
+    fd = _open(out_file, O_WRONLY | O_CREAT | O_TRUNC, DEFAULT_PERMISSION);
     if (fd < 0) PFATAL("Unable to create '%s'", out_file);
 
   }

--- a/afl-tmin.c
+++ b/afl-tmin.c
@@ -343,15 +343,12 @@ static void write_to_file(u8* path, u8* mem, u32 len) {
 
   s32 ret;
 
-  _unlink(path); /* Ignore errors */
-
-  ret = _open(path, O_RDWR | O_CREAT | O_EXCL | O_BINARY, DEFAULT_PERMISSION);
+  ret = _open(path, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, DEFAULT_PERMISSION);
 
   if (ret < 0) PFATAL("Unable to create '%s'", path);
 
   ck_write(ret, mem, len, path);
 
-  _lseek(ret, 0, SEEK_SET);
   _close(ret);
 
 }


### PR DESCRIPTION
Disk I/O is the bottleneck for fast harnesses (verified by profiling). Reducing the amount of those calls should give us an immediate performance gain.
I apologize but I won't have time to test this change, as I need to start a project at work, but if something seems amiss tell me and I'll try to make some time to fix it.