### PR TITLE
Fixed the issue that custom mutator function is not invoked

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -5650,12 +5650,14 @@ static u8 fuzz_one(char** argv) {
    *****************/
 
   // Prefer a custom mutator that accepts the performance score as an energy value.
-  if (dll_mutate_testcase_with_energy_ptr)
+  if (dll_mutate_testcase_with_energy_ptr) {
     if (dll_mutate_testcase_with_energy_ptr(argv, in_buf, len, perf_score, common_fuzz_stuff))
       goto abandon_entry;
-  else if (dll_mutate_testcase_ptr)
+  }
+  else if (dll_mutate_testcase_ptr) {
     if (dll_mutate_testcase_ptr(argv, in_buf, len, common_fuzz_stuff))
       goto abandon_entry;
+  }
 
   /* Skip right away if -d is given, if we have done deterministic fuzzing on
      this entry ourselves (was_fuzzed), or if it has gone through deterministic


### PR DESCRIPTION
I tried custom mutator functionality as readme, and implemented the "dll_muate_testcase" function. However, I found my custom mutator was never called, so I looked at the source code of winafl and found a minor bug in the following code.

```
  // Prefer a custom mutator that accepts the performance score as an energy value.
  if (dll_mutate_testcase_with_energy_ptr)
    if (dll_mutate_testcase_with_energy_ptr(argv, in_buf, len, perf_score, common_fuzz_stuff))
      goto abandon_entry;
  else if (dll_mutate_testcase_ptr)
    if (dll_mutate_testcase_ptr(argv, in_buf, len, common_fuzz_stuff))
      goto abandon_entry;
```

It seems like WinAFL intends to call a custom mutator function if either 'dll_mutate_testcase_with_energy' or 'dll_mutate_testcase' function is given by a user. However, "dll_mutate_testcase" is never called if a user only implements "dll_muate_testcase" without implementing "dll_mutate_testcase_with_energy" because of if-else priority. Making the above code clear, it will be the following. 
```
 if (dll_mutate_testcase_with_energy_ptr) {
      if (dll_mutate_testcase_with_energy_ptr(argv, in_buf, len, perf_score, common_fuzz_stuff))
          goto abandon_entry;
      else if (dll_mutate_testcase_ptr)
          if (dll_mutate_testcase_ptr(argv, in_buf, len, common_fuzz_stuff))
              goto abandon_entry;
}
```
So, I have fixed the above issue adding brackets, and checked to work well.