### PR TITLE
Coverage Exclusion Range

### DIFF
--- a/winafl.c
+++ b/winafl.c
@@ -940,7 +940,7 @@ options_init(client_id_t id, int argc, const char *argv[])
                 options.target_modules->exclusion_range_end = strtoul(token, NULL, 16);
             }
             else {
-                USAGE_CHECK(delimiter_count == 0, "invalid coverage module exclusion range syntax");
+                USAGE_CHECK(delimiter_count > 0, "invalid coverage module exclusion range syntax");
                 target_module_name = coverage_module;
             }
 


### PR DESCRIPTION
This PR adds the ability to specify a range to exclude from code coverage instrumentation, inside a module.
I found this to be useful for unstable code that I don't want to fuzz, but that is inside a module that I care about.
This works by adding a relative address range on the command line options, surrounded by '?'.

`module.dll?0x23f67?0x4da60?`