### PR TITLE
Update help / usage message

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -44,7 +44,7 @@
 #pragma comment(lib, "pdh.lib")
 
 #define VERSION "2.43b"
-#define WINAFL_VERSION "1.16b"
+#define WINAFL_VERSION "1.17"
 
 #include "config.h"
 #include "types.h"
@@ -7489,6 +7489,7 @@ static void usage(u8* argv0) {
         "  -D dir       - directory with DynamoRIO binaries (drrun, drconfig)\n"
         "  -w winafl    - Path to winafl.dll\n"
         "  -P           - use Intel PT tracing mode\n"
+        "  -y           - use TinyInst tracing mode\n"
         "  -Y           - enable the static instrumentation mode\n\n"
 
        "Execution control settings:\n\n"


### PR DESCRIPTION
Hi @ifratric, I'm very excited to see TinyInst support in WinAFL.

I compiled WinAFL with support for TinyInst and ran into some problems initially. The first debug step I did was to run winafl and check the help menu. I was looking for the `-y` option but it wasn't there. The next thing I did was look at the version and compare with older builds. Neither of these helped me determine if I actually compiled in TinyInst support so I inspected the binary with IDA to confirm.

I proposing a few changes to help others who may face the same situation:
- bump WINAFL_VERSION to indicate support for TinyInst
- Add `-y` option to usage message