### PR TITLE
Add -l option for adjustable block deletion

### DIFF
--- a/afl-tmin.c
+++ b/afl-tmin.c
@@ -80,6 +80,7 @@ static u32 in_len,                    /* Input data length                 */
            missed_crashes,            /* Misses due to crashes             */
            missed_paths,              /* Misses due to exec path diffs     */
            exec_tmout = EXEC_TIMEOUT; /* Exec timeout (ms)                 */
+           del_len_limit;             /* Minimum block deletion length     */
 
 static u64 mem_limit = MEM_LIMIT,     /* Memory limit (MB)                 */
            start_time;                /* Tick count at the beginning       */
@@ -89,7 +90,7 @@ static HANDLE pipe_handle;            /* Handle of the name pipe          */
 static u64    name_seed;              /* Random integer to have a unique shm/pipe name */
 static HANDLE devnul_handle;          /* Handle of the nul device         */
 static u8     sinkhole_stds = 1;      /* Sink-hole stdout/stderr messages?*/
-static char   *fuzzer_id = NULL;      /* The fuzzer ID or a randomized 
+static char   *fuzzer_id = NULL;      /* The fuzzer ID or a randomized
                                          seed allowing multiple instances */
 
 static u8  crash_mode,                /* Crash-centric mode?               */
@@ -910,6 +911,7 @@ next_pass:
   if (no_minimize) goto alphabet_minimization;
   del_len = next_p2(in_len / TRIM_START_STEPS);
   stage_o_len = in_len;
+  if (!del_len_limit) { del_len_limit = 1; }
 
   ACTF(cBRI "Stage #1: " cRST "Removing blocks of data...");
 
@@ -965,7 +967,7 @@ next_del_blksize:
 
   }
 
-  if (del_len > 1 && in_len >= 1) {
+  if (del_len > del_len_limit && in_len >= 1) {
 
     del_len /= 2;
     goto next_del_blksize;
@@ -1218,6 +1220,7 @@ static void usage(u8* argv0) {
        "Minimization settings:\n\n"
 
        "  -e            - solve for edge coverage only, ignore hit counts\n"
+       "  -l bytes      - set minimum block deletion length to speed up minimization\n"
        "  -x            - treat non-zero exit codes as crashes\n"
        "  -N            - only normalize, skip length minimization. Implies -S\n"
        "  -M            - only minimize length, skip normalization. Implies -S\n"
@@ -1341,7 +1344,7 @@ static void extract_client_params(u32 argc, char** argv) {
 int main(int argc, char** argv) {
 
   s32 opt;
-  u8  mem_limit_given = 0, timeout_given = 0;
+  u8  mem_limit_given = 0, timeout_given = 0, del_limit_given = 0;
   char** use_argv;
   errno_t status;
 
@@ -1359,7 +1362,7 @@ int main(int argc, char** argv) {
   SAYF("Based on WinAFL " cBRI VERSION cRST " by <ifratric@google.com>\n");
   SAYF("Based on AFL " cBRI VERSION cRST " by <lcamtuf@google.com>\n");
 
-  while ((opt = getopt(argc,argv,"+i:o:f:m:t:B:D:xeQYVNMS")) > 0)
+  while ((opt = getopt(argc,argv,"+i:o:f:m:t:B:D:l:xeQYVNMS")) > 0)
 
     switch (opt) {
 
@@ -1455,6 +1458,20 @@ int main(int argc, char** argv) {
 
         break;
 
+      case 'l':
+        if (del_limit_given) FATAL("Multiple -l options not supported");
+        del_limit_given = 1;
+
+        if (no_minimize) FATAL("-M and -l incompatible");
+
+        if (!optarg) FATAL("Wrong usage of -l");
+        if (optarg[0] == '-') FATAL("Dangerously low value of -l");
+
+        del_len_limit = atoi(optarg);
+        if (del_len_limit < 1 || del_len_limit >= TMIN_MAX_FILE) FATAL("Value of -l out of range between 1 and TMIN_MAX_FILE");
+
+        break;
+
       case 'B': /* load bitmap */
 
         /* This is a secret undocumented option! It is speculated to be useful
@@ -1502,6 +1519,7 @@ int main(int argc, char** argv) {
 
         if (no_normalize) FATAL("Multiple -M options not supported");
         if (no_minimize) FATAL("-N and -M mutually exclusive");
+        if (del_limit_given) FATAL("-M and -l incompatible");
         no_normalize = 1;
         break;
 


### PR DESCRIPTION
- Introduce the -l option to set min block deletion length using powers of 2 (e.g., 1, 2, 4, 8, 16, ...).
- This enables a trade-off between minimization thoroughness and speed.
- Adjusting del_len_limit allows for faster processing, as doubling it roughly halves the minimization time.
- Closes #431 